### PR TITLE
Use Plutus built-in for modulo inverses

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ cabal test all
 Below are the execution costs of Plutus scripts running the Halo2 verifier for various circuits (with multiopen KZG
 variant from Halo2 book):
 
-| Circuit description             | Script size<br/>(% of script limit 14kb) | CPU usage               | Mem usage          |
-|---------------------------------|------------------------------------------|-------------------------|--------------------|
-| **Simple mul**                  | 6715  (46.8%)                            | 3,773,051,088  (37.73%) | 1,885,112 (13.46%) |
-| **Lookup table**                | 11517 (80.3%)                            | 6,593,546,629  (65.94%) | 3,584,198 (25.6%)  |
-| **ATMS (50 out of 90)**         | 12105 (84.3%)                            | 7,724,074,950  (77.24%) | 3,624,362 (25.8%)  |
-| **ATMS (228 out of 408)**       | 12105 (84.3%)                            | 7,724,074,950  (77.24%) | 3,624,362 (25.9%)  |
-| **ATMS (50/90) + lookup table** | 14403 (100.4%)                           | 9,197,113,158  (91.97%) | 4,832,174 (34.5%)  |
+| Circuit description             | Script size<br/>(% of script limit 14kb) | CPU usage               | Mem usage         |
+|---------------------------------|------------------------------------------|-------------------------|-------------------|
+| **Simple mul**                  | 6551  (45.7%)                            | 3,764,901,258  (37.65%) | 1,745,624 (12.4%) |
+| **Lookup table**                | 11359 (79.2%)                            | 6,585,396,799  (65.85%) | 3,444,710 (24.6%) |
+| **ATMS (50 out of 90)**         | 11947 (83.3%)                            | 7,715,973,120  (77.16%) | 3,485,174 (24.8%) |
+| **ATMS (50 out of 90)**         | 11947 (83.3%)                            | 7,715,973,120  (77.16%) | 3,485,174 (24.8%) |
+| **ATMS (50/90) + lookup table** | 14242 (99.3%)                            | 9,188,915,328  (91.89%) | 4,692,386 (33.5%) |
 
 **Note that the benchmark numbers are approximate.** Even for the same circuit, the verifier’s execution cost may vary
 slightly depending on the specific proof being verified. This variation stems from the randomness used during proof

--- a/README.md
+++ b/README.md
@@ -106,32 +106,33 @@ The repository includes several example circuits:
 * `atms_with_lookups` - A circuit that verifies ATMS signature and lookup argument
 * `lookup_table` - A circuit with lookup argument
 
-those circuits can be run in 2 versions one with GWC19 flavor of KZG and one with halo2 variant
+These circuits can be run in two versions: one using the GWC19 flavor of multi-open KZG, and the other using the
+multi-open protocol described in Halo2 book.
 
 ```bash
-# Simple multiplication circuit GWC19 KZG
+# Simple multiplication circuit (Halo2 KZG)
 cargo run --example simple_mul
 
-# Simple multiplication circuit halo2 KZG
-cargo run --example simple_mul halo2
+# Simple multiplication circuit (GWC19 KZG)
+cargo run --example simple_mul gwc_kzg
 
-# ATMS (Aggregate Threshold Multisignature) circuit GWC19 KZG
+# ATMS (Aggregate Threshold Multisignature) circuit Halo2 KZG
 cargo run --example atms
 
-# ATMS (Aggregate Threshold Multisignature) circuit halo2 KZG
-cargo run --example atms halo2
+# ATMS (Aggregate Threshold Multisignature) circuit GWC19 KZG
+cargo run --example atms gwc_kzg
 
-# ATMS with dummy lookup tables GWC19 KZG
+# ATMS with dummy lookup tables (Halo2 KZG)
 cargo run --example atms_with_lookups
 
-# ATMS with dummy lookup tables halo2 KZG
-cargo run --example atms_with_lookups halo2
+# ATMS with dummy lookup tables (GWC19 KZG)
+cargo run --example atms_with_lookups gwc_kzg
 
-# Lookup table circuit GWC19 KZG
+# Lookup table circuit (Halo2 KZG)
 cargo run --example lookup_table
 
-# Simple multiplication circuit halo2 KZG
-cargo run --example atms_with_lookups halo2
+# Simple multiplication circuit (GWC19 KZG)
+cargo run --example atms_with_lookups gwc_kzg
 
 # With detailed logging
 RUST_LOG=debug cargo run --example simple_mul
@@ -156,6 +157,7 @@ locations within the plutus-verifier folder:
 ### Plutus part
 
 After the Rust part is executed you can test Plutus verifier as follows:
+
 ```bash
 nix develop github:input-output-hk/devx#ghc96-iog
 cd plutus-verifier
@@ -165,17 +167,20 @@ cabal test all
 
 ## Benchmarks
 
-Below are the execution costs of Plutus scripts running the Halo2 verifier for various circuits (GWC19 KZG variant):
+Below are the execution costs of Plutus scripts running the Halo2 verifier for various circuits (with multiopen KZG
+variant from Halo2 book):
 
-| Circuit description             | Script size<br/>(% of script limit 14kb) | CPU usage               | Mem usage         |
-|---------------------------------|------------------------------------------|-------------------------|-------------------|
-| **Simple mul**                  | 6498  (45.3%)                            | 5,246,865,172  (52.47%) | 3,750,211 (26.7%) |
-| **Lookup table**                | 11981 (83.56%)                           | 8,508,800,375  (85.09%) | 4,506,048 (32.1%) |
-| **ATMS (50 out of 90)**         | 12542 (87.5%)                            | 9,049,726,110  (90.5%)  | 4,531,396 (32.3%) |
-| **ATMS (228 out of 408)**       | 12542 (87.5%)                            | 9,037,616,234  (90.3%)  | 4,488,266 (32.0%) |
-| **ATMS (50/90) + lookup table** | 15246 (106.3%)                           | 10,733,382,733 (107.3%) | 4,882,403 (34.8%) |
+| Circuit description             | Script size<br/>(% of script limit 14kb) | CPU usage               | Mem usage          |
+|---------------------------------|------------------------------------------|-------------------------|--------------------|
+| **Simple mul**                  | 6715  (46.8%)                            | 3,773,051,088  (37.73%) | 1,885,112 (13.46%) |
+| **Lookup table**                | 11517 (80.3%)                            | 6,593,546,629  (65.94%) | 3,584,198 (25.6%)  |
+| **ATMS (50 out of 90)**         | 12105 (84.3%)                            | 7,724,074,950  (77.24%) | 3,624,362 (25.8%)  |
+| **ATMS (228 out of 408)**       | 12105 (84.3%)                            | 7,724,074,950  (77.24%) | 3,624,362 (25.9%)  |
+| **ATMS (50/90) + lookup table** | 14403 (100.4%)                           | 9,197,113,158  (91.97%) | 4,832,174 (34.5%)  |
 
-**Note that the benchmark numbers are approximate.** Even for the same circuit, the verifier’s execution cost may vary slightly depending on the specific proof being verified. This variation stems from the randomness used during proof generation, which can be influenced by the initial seed or the platform on which the prover runs.
+**Note that the benchmark numbers are approximate.** Even for the same circuit, the verifier’s execution cost may vary
+slightly depending on the specific proof being verified. This variation stems from the randomness used during proof
+generation, which can be influenced by the initial seed or the platform on which the prover runs.
 
 ## License
 

--- a/examples/atms.rs
+++ b/examples/atms.rs
@@ -30,15 +30,15 @@ fn main() {
 
     match &args[1..] {
         [] => {
-            compile_atms_circuit::<GwcKZGCommitmentScheme<Bls12>>();
-        }
-        [command] if command == "halo2" => {
             compile_atms_circuit::<KZGCommitmentScheme<Bls12>>();
         }
+        [command] if command == "gwc_kzg" => {
+            compile_atms_circuit::<GwcKZGCommitmentScheme<Bls12>>();
+        }
         _ => {
-            println!(
-                "usage: to run halo2 KZG variant pass halo2, to run GWC19 variant do not pass any option"
-            )
+            println!("Usage:");
+            println!("- to run the example: `cargo run --example example_name`");
+            println!("- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`");
         }
     }
 }
@@ -54,8 +54,8 @@ pub fn compile_atms_circuit<
     let seed = [0u8; 32]; // UNSAFE, constant seed is used for testing purposes
     let mut rng: StdRng = SeedableRng::from_seed(seed);
 
-    let num_parties = 90;
-    let threshold = 50;
+    let num_parties = 6;
+    let threshold = 3;
     let msg = Base::from(42u64);
 
     let (signatures, pks, pks_comm) =

--- a/examples/atms.rs
+++ b/examples/atms.rs
@@ -38,7 +38,9 @@ fn main() {
         _ => {
             println!("Usage:");
             println!("- to run the example: `cargo run --example example_name`");
-            println!("- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`");
+            println!(
+                "- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`"
+            );
         }
     }
 }

--- a/examples/atms_with_lookups.rs
+++ b/examples/atms_with_lookups.rs
@@ -46,15 +46,15 @@ fn main() {
 
     match &args[1..] {
         [] => {
-            compile_atms_lookup_circuit::<GwcKZGCommitmentScheme<Bls12>>();
-        }
-        [command] if command == "halo2" => {
             compile_atms_lookup_circuit::<KZGCommitmentScheme<Bls12>>();
         }
+        [command] if command == "gwc_kzg" => {
+            compile_atms_lookup_circuit::<GwcKZGCommitmentScheme<Bls12>>();
+        }
         _ => {
-            println!(
-                "usage: to run halo2 KZG variant pass halo2, to run GWC19 variant do not pass any option"
-            )
+            println!("Usage:");
+            println!("- to run the example: `cargo run --example example_name`");
+            println!("- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`");
         }
     }
 }

--- a/examples/atms_with_lookups.rs
+++ b/examples/atms_with_lookups.rs
@@ -54,7 +54,9 @@ fn main() {
         _ => {
             println!("Usage:");
             println!("- to run the example: `cargo run --example example_name`");
-            println!("- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`");
+            println!(
+                "- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`"
+            );
         }
     }
 }

--- a/examples/lookup_table.rs
+++ b/examples/lookup_table.rs
@@ -30,15 +30,15 @@ fn main() {
 
     match &args[1..] {
         [] => {
-            compile_lookup_table_circuit::<GwcKZGCommitmentScheme<Bls12>>();
-        }
-        [command] if command == "halo2" => {
             compile_lookup_table_circuit::<KZGCommitmentScheme<Bls12>>();
         }
+        [command] if command == "gwc_kzg" => {
+            compile_lookup_table_circuit::<GwcKZGCommitmentScheme<Bls12>>();
+        }
         _ => {
-            println!(
-                "usage: to run halo2 KZG variant pass halo2, to run GWC19 variant do not pass any option"
-            )
+            println!("Usage:");
+            println!("- to run the example: `cargo run --example example_name`");
+            println!("- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`");
         }
     }
 }

--- a/examples/lookup_table.rs
+++ b/examples/lookup_table.rs
@@ -38,7 +38,9 @@ fn main() {
         _ => {
             println!("Usage:");
             println!("- to run the example: `cargo run --example example_name`");
-            println!("- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`");
+            println!(
+                "- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`"
+            );
         }
     }
 }

--- a/examples/simple_mul.rs
+++ b/examples/simple_mul.rs
@@ -31,26 +31,26 @@ fn main() {
 
     match &args[1..] {
         [] => {
-            compile_simple_mul_circuit::<GwcKZGCommitmentScheme<Bls12>>();
-        }
-        [command] if command == "halo2" => {
             compile_simple_mul_circuit::<KZGCommitmentScheme<Bls12>>();
         }
+        [command] if command == "gwc_kzg" => {
+            compile_simple_mul_circuit::<GwcKZGCommitmentScheme<Bls12>>();
+        }
         _ => {
-            println!(
-                "usage: to run halo2 KZG variant pass halo2, to run GWC19 variant do not pass any option"
-            )
+            println!("Usage:");
+            println!("- to run the example: `cargo run --example example_name`");
+            println!("- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`");
         }
     }
 }
 
 fn compile_simple_mul_circuit<
     S: PolynomialCommitmentScheme<
-            Scalar,
-            Commitment = G1Projective,
-            Parameters = ParamsKZG<Bls12>,
-            VerifierParameters = ParamsVerifierKZG<Bls12>,
-        > + ExtractKZG,
+        Scalar,
+        Commitment=G1Projective,
+        Parameters=ParamsKZG<Bls12>,
+        VerifierParameters=ParamsVerifierKZG<Bls12>,
+    > + ExtractKZG,
 >() {
     // Prepare the private and public inputs to the circuit!
     let constant = Scalar::from(7);
@@ -98,7 +98,7 @@ fn compile_simple_mul_circuit<
         &mut rng,
         &mut transcript,
     )
-    .expect("proof generation should not fail");
+        .expect("proof generation should not fail");
 
     let proof = transcript.finalize();
 
@@ -111,7 +111,7 @@ fn compile_simple_mul_circuit<
         instances,
         &mut transcript_verifier,
     )
-    .expect("prepare verification failed");
+        .expect("prepare verification failed");
 
     verifier
         .verify(&params.verifier_params())
@@ -121,7 +121,7 @@ fn compile_simple_mul_circuit<
         "./plutus-verifier/plutus-halo2/test/Generic/serialized_proof.json".to_string(),
         proof,
     )
-    .unwrap();
+        .unwrap();
 
     generate_plinth_verifier(&params, &vk, instances, |a| hex::encode(a.to_bytes()))
         .expect("Plinth verifier generation failed");

--- a/examples/simple_mul.rs
+++ b/examples/simple_mul.rs
@@ -39,18 +39,20 @@ fn main() {
         _ => {
             println!("Usage:");
             println!("- to run the example: `cargo run --example example_name`");
-            println!("- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`");
+            println!(
+                "- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`"
+            );
         }
     }
 }
 
 fn compile_simple_mul_circuit<
     S: PolynomialCommitmentScheme<
-        Scalar,
-        Commitment=G1Projective,
-        Parameters=ParamsKZG<Bls12>,
-        VerifierParameters=ParamsVerifierKZG<Bls12>,
-    > + ExtractKZG,
+            Scalar,
+            Commitment = G1Projective,
+            Parameters = ParamsKZG<Bls12>,
+            VerifierParameters = ParamsVerifierKZG<Bls12>,
+        > + ExtractKZG,
 >() {
     // Prepare the private and public inputs to the circuit!
     let constant = Scalar::from(7);
@@ -98,7 +100,7 @@ fn compile_simple_mul_circuit<
         &mut rng,
         &mut transcript,
     )
-        .expect("proof generation should not fail");
+    .expect("proof generation should not fail");
 
     let proof = transcript.finalize();
 
@@ -111,7 +113,7 @@ fn compile_simple_mul_circuit<
         instances,
         &mut transcript_verifier,
     )
-        .expect("prepare verification failed");
+    .expect("prepare verification failed");
 
     verifier
         .verify(&params.verifier_params())
@@ -121,7 +123,7 @@ fn compile_simple_mul_circuit<
         "./plutus-verifier/plutus-halo2/test/Generic/serialized_proof.json".to_string(),
         proof,
     )
-        .unwrap();
+    .unwrap();
 
     generate_plinth_verifier(&params, &vk, instances, |a| hex::encode(a.to_bytes()))
         .expect("Plinth verifier generation failed");

--- a/note.md
+++ b/note.md
@@ -1,9 +1,0 @@
-Idea for the optimization:
-
-1. Remove modulo inverse calls from halo2 version of KZG
-2. Provide pairs of `[(A, invA)]` with proof data, such that it contains all inverses needed in particular proof verification
-3. At the beginning of the verifier add logic that will check for all elements in the list that `1 = A * invA mod prime`
-4. Implement logic that will instead of calculating inverse on chain do a lookup in provided pairs
-
-[update]
-there is a builtin function called `expModInteger` that can be used here, and requires no additional data to be sent

--- a/note.md
+++ b/note.md
@@ -4,3 +4,6 @@ Idea for the optimization:
 2. Provide pairs of `[(A, invA)]` with proof data, such that it contains all inverses needed in particular proof verification
 3. At the beginning of the verifier add logic that will check for all elements in the list that `1 = A * invA mod prime`
 4. Implement logic that will instead of calculating inverse on chain do a lookup in provided pairs
+
+[update]
+there is a builtin function called `expModInteger` that can be used here, and requires no additional data to be sent

--- a/note.md
+++ b/note.md
@@ -1,0 +1,6 @@
+Idea for the optimization:
+
+1. Remove modulo inverse calls from halo2 version of KZG
+2. Provide pairs of `[(A, invA)]` with proof data, such that it contains all inverses needed in particular proof verification
+3. At the beginning of the verifier add logic that will check for all elements in the list that `1 = A * invA mod prime`
+4. Implement logic that will instead of calculating inverse on chain do a lookup in provided pairs

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/BlsTypes.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/BlsTypes.hs
@@ -249,11 +249,7 @@ instance MultiplicativeMonoid Fp where
 
 {-# INLINEABLE modularExponentiationFp #-}
 modularExponentiationFp :: Fp -> Integer -> Fp
-modularExponentiationFp b e
-    | e < 0 = zero
-    | e == 0 = one
-    | even e = modularExponentiationFp (b * b) (e `divide` 2)
-    | otherwise = b * modularExponentiationFp (b * b) ((e - 1) `divide` 2)
+modularExponentiationFp (Fp b) e = Fp (expModInteger b e bls12_381_field_prime)
 
 instance Module Integer Fp where
     {-# INLINEABLE scale #-}

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/BlsTypes.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/BlsTypes.hs
@@ -24,7 +24,6 @@ module Plutus.Crypto.BlsTypes (
     MultiplicativeGroup (..),
     pow,
     powMod,
-    modularExponentiationScalar,
     modularExponentiationFp,
     modularExponentiationFp2,
     reverseByteString,
@@ -50,6 +49,7 @@ import PlutusTx.Builtins (
     bls12_381_G2_uncompress,
     consByteString,
     emptyByteString,
+    expModInteger,
     indexByteString,
  )
 import PlutusTx.Numeric (
@@ -73,11 +73,9 @@ import PlutusTx.Prelude (
     even,
     modulo,
     otherwise,
-    trace,
     ($),
     (&&),
     (.),
-    (/=),
     (<>),
     (>),
     (||),
@@ -174,16 +172,6 @@ class (MultiplicativeMonoid a) => MultiplicativeGroup a where
     div :: a -> a -> a
     recip :: a -> a
 
--- Modular exponentiation by squaring. This assumes that the exponent is
--- a big endian bytestring. Note that integegerToByteString is little endian.
-{-# INLINEABLE modularExponentiationScalar #-}
-modularExponentiationScalar :: Scalar -> Integer -> Scalar
-modularExponentiationScalar b e
-    | e < 0 = zero
-    | e == 0 = one
-    | even e = modularExponentiationScalar (b * b) (e `divide` 2)
-    | otherwise = b * modularExponentiationScalar (b * b) ((e - 1) `divide` 2)
-
 -- Reverse a builtin byte string of arbitrary length
 -- This can convert between little and big endian.
 {-# INLINEABLE reverseByteString #-}
@@ -203,15 +191,6 @@ powMod b e
     | even e = powMod (b * b) (e `divide` 2)
     | otherwise = b * powMod (b * b) ((e - 1) `divide` 2)
 
--- In math this is b^a mod p, where b is of type scalar and a any integer
--- note that there is still some overhead here due to the conversion from
--- little endian to big endian (and bs <-> integer). This can be
--- optimized in the future.
-instance Module Integer Scalar where
-    {-# INLINEABLE scale #-}
-    scale :: Integer -> Scalar -> Scalar
-    scale a b = modularExponentiationScalar b a -- powMod b a is also a correct implementation
-
 instance MultiplicativeGroup Scalar where
     {-# INLINEABLE div #-}
     div :: Scalar -> Scalar -> Scalar
@@ -220,17 +199,7 @@ instance MultiplicativeGroup Scalar where
         | otherwise = a * recip b
     {-# INLINEABLE recip #-}
     recip :: Scalar -> Scalar
-    recip (Scalar a) = Scalar (go a bls12_381_field_prime 1 0)
-      where
-        !_ = trace ("calling modulo inverse for scalar " <> show a) ()
-        go !u !v !x1 !x2 =
-            if u /= 1
-                then
-                    let !q = v `divide` u
-                        r = v - q * u
-                        x = x2 - q * x1
-                     in go r u x x1
-                else x1 `modulo` bls12_381_field_prime
+    recip (Scalar a) = Scalar (expModInteger a (-1) bls12_381_field_prime)
 
 -- The field elements are the x and y coordinates of the points on the curve.
 newtype Fp = Fp {unFp :: Integer} deriving (Haskell.Show, Haskell.Eq)

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/BlsTypes.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/BlsTypes.hs
@@ -243,7 +243,7 @@ instance MultiplicativeMonoid Fp where
 
 {-# INLINEABLE modularExponentiationFp #-}
 modularExponentiationFp :: Fp -> Integer -> Fp
-modularExponentiationFp (Fp b) e = Fp (expModInteger b e bls12_381_field_prime)
+modularExponentiationFp (Fp b) e = Fp (expModInteger b e bls12_381_base_prime)
 
 instance Module Integer Fp where
     {-# INLINEABLE scale #-}

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/BlsTypes.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/BlsTypes.hs
@@ -181,15 +181,9 @@ reverseByteString bs
     | otherwise =
         reverseByteString (dropByteString 1 bs) <> consByteString (indexByteString bs 0) emptyByteString
 
--- this one costs around 12.1% of cpu budget
--- while bitshifts modExp cost around 9.6%
 {-# INLINEABLE powMod #-}
 powMod :: Scalar -> Integer -> Scalar
-powMod b e
-    | e < 0 = zero
-    | e == 0 = one
-    | even e = powMod (b * b) (e `divide` 2)
-    | otherwise = b * powMod (b * b) ((e - 1) `divide` 2)
+powMod (Scalar b) e = Scalar (expModInteger b e bls12_381_field_prime)
 
 instance MultiplicativeGroup Scalar where
     {-# INLINEABLE div #-}

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Constants.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Constants.hs
@@ -6,19 +6,19 @@ module Plutus.Crypto.Constants where
 import Plutus.Crypto.BlsTypes (Scalar, bls12_381_field_prime, mkScalar)
 import PlutusTx.Prelude (modulo)
 
--- todo this is constant from halo2 "halo2_proofs::halo2curves::bls12_381::Scalar::DELTA" find equivalent in plutus bls12_381
+-- this is constant from halo2 "halo2_proofs::halo2curves::bls12_381::Scalar::DELTA"
 scalarDelta :: Scalar
 scalarDelta =
     mkScalar
         (0x08634d0aa021aaf843cab354fabb0062f6502437c6a09c006c083479590189d7 `modulo` bls12_381_field_prime)
 
--- todo this is constant from halo2 "halo2_proofs::halo2curves::bls12_381::Scalar::ONE" find equivalent in plutus bls12_381
+-- this is constant from halo2 "halo2_proofs::halo2curves::bls12_381::Scalar::ONE"
 scalarOne :: Scalar
 scalarOne =
     mkScalar
         (0x0000000000000000000000000000000000000000000000000000000000000001 `modulo` bls12_381_field_prime)
 
--- todo this is constant from halo2 "halo2_proofs::halo2curves::bls12_381::Scalar::ZERO" find equivalent in plutus bls12_381
+-- this is constant from halo2 "halo2_proofs::halo2curves::bls12_381::Scalar::ZERO"
 scalarZero :: Scalar
 scalarZero =
     mkScalar

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2.hs
@@ -35,7 +35,6 @@ import Plutus.Crypto.Halo2.Proof as Proof (
  )
 import Plutus.Crypto.Halo2.Transcript as Transcript (
     Transcript,
-    addPointToTranscript,
     addScalarToTranscript,
     squeezeChallange,
  )

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2.hs
@@ -18,7 +18,6 @@ import Plutus.Crypto.BlsTypes as BlsTypes (
     mkScalar,
     modularExponentiationFp,
     modularExponentiationFp2,
-    modularExponentiationScalar,
     one,
     pow,
     powMod,

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/ApplicativeParser.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/ApplicativeParser.hs
@@ -42,7 +42,7 @@ run transcriptRepr (Parser f) proof = f (proof, Transcript.addScalarToTranscript
 readPoint :: Parser BuiltinBLS12_381_G1_Element
 readPoint = Parser $ \(proof, transcript) ->
     let (point, proof') = Proof.readPoint proof
-        transcript' = Transcript.addPointToTranscript' transcript point
+        transcript' = Transcript.addPointToTranscript transcript point
      in (point, (proof', transcript'))
 
 {-# INLINE readScalar #-}

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
@@ -49,7 +49,7 @@ import PlutusTx.Prelude (
     enumFromTo,
     max,
     one,
-    trace,
+--    trace,
     zero,
     (*),
     (+),

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
@@ -151,7 +151,6 @@ evaluateLagrangePolynomials pointSets q_eval_sets x2 x3 proofX3QEvals =
     foldl
         ( \accEval ((points, evals), proofQEval) ->
             let
-                !_ = trace "Evaluating lagrange polynomial" ()
                 rEval = lagrangeEvaluation (zip points evals) x3
                 den = foldl (\acc point -> acc * (x3 - point)) one points
                 eval = (proofQEval - rEval) * (recip den)

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
@@ -151,6 +151,7 @@ evaluateLagrangePolynomials pointSets q_eval_sets x2 x3 proofX3QEvals =
     foldl
         ( \accEval ((points, evals), proofQEval) ->
             let
+--                !_ = trace "Evaluating lagrange polynomial" ()
                 rEval = lagrangeEvaluation (zip points evals) x3
                 den = foldl (\acc point -> acc * (x3 - point)) one points
                 eval = (proofQEval - rEval) * (recip den)

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/LagrangePolynomialEvaluation.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/LagrangePolynomialEvaluation.hs
@@ -75,6 +75,16 @@ lagrangeEvaluation pts x =
 basis :: Scalar -> Scalar -> [(Scalar, Scalar)] -> Scalar
 basis x xi pts =
     let
+--        !_ =
+--            trace
+--                ( "calculating basis for x = "
+--                    <> show x
+--                    <> " xi = "
+--                    <> show xi
+--                    <> " pts = "
+--                    <> show pts
+--                )
+--                ()
         (totalNumerator, totalDenominator) =
             foldl
                 ( \(numerator, denominator) (xj, _) ->

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/LagrangePolynomialEvaluation.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/LagrangePolynomialEvaluation.hs
@@ -96,16 +96,6 @@ lagrangeEvaluation pts x =
 basis :: Scalar -> Scalar -> [(Scalar, Scalar)] -> Scalar
 basis x xi pts =
     let
-        !_ =
-            trace
-                ( "calculating basis for x = "
-                    <> show x
-                    <> " xi = "
-                    <> show xi
-                    <> " pts = "
-                    <> show pts
-                )
-                ()
         (totalNumerator, totalDenominator) =
             foldl
                 ( \(numerator, denominator) (xj, _) ->

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/LagrangePolynomialEvaluation.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/LagrangePolynomialEvaluation.hs
@@ -14,20 +14,17 @@ import Plutus.Crypto.BlsTypes (
     recip,
  )
 import Plutus.Crypto.BlsUtils (rotateOmega)
-import PlutusTx.List (foldl, head, reverse, tail, zip)
+import PlutusTx.List (foldl, zip)
 import PlutusTx.Prelude (
     AdditiveMonoid (..),
     MultiplicativeMonoid (one),
     fmap,
-    trace,
     ($),
     (*),
     (+),
     (-),
     (/=),
-    (<>),
  )
-import PlutusTx.Show (show)
 import qualified Prelude
 
 {- | Computes evaluations (at the point `x`, where `xn = x^n`) of Lagrange
@@ -53,7 +50,7 @@ lagrangePolynomialBasis x xn barycentricWeight rotations = result
     !common = (xn - one) * barycentricWeight
 
     inversed :: [Scalar]
-    !inversed = batchInverses $ fmap (\rotatedOmega -> x - rotatedOmega) rotations
+    !inversed = fmap (\rotatedOmega -> recip (x - rotatedOmega)) rotations
 
     result :: [Scalar]
     !result = fmap (\(inv, rotatedOmega) -> inv * common * rotatedOmega) $ zip inversed rotations
@@ -61,24 +58,6 @@ lagrangePolynomialBasis x xn barycentricWeight rotations = result
 getRotatedOmegas :: Scalar -> Scalar -> Prelude.Integer -> Prelude.Integer -> [Scalar]
 getRotatedOmegas omega omegaInv from to =
     fmap (rotateOmega omega omegaInv one) [from .. to]
-
-batchInverses :: [Scalar] -> [Scalar]
-batchInverses [] = []
-batchInverses l@(a : aCons) = aInv
-  where
-    !bRev =
-        foldl
-            (\accum elem -> elem * head accum : accum)
-            [a]
-            aCons
-    !aRev = reverse l
-    !bInvLast = recip $ head bRev
-    !(aInv', bInv_1) =
-        foldl
-            (\(aInvAccum, bInv_i) (b_i_min_1, a_i) -> (bInv_i * b_i_min_1 : aInvAccum, bInv_i * a_i))
-            ([], bInvLast)
-            (zip (tail bRev) aRev)
-    !aInv = bInv_1 : aInv'
 
 -- this function first does lagrange interpolation based on list of tuples,
 -- where first element is treated as x and second as y

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Transcript.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Transcript.hs
@@ -5,7 +5,6 @@ module Plutus.Crypto.Halo2.Transcript (
     squeezeChallange,
     addScalarToTranscript,
     addPointToTranscript,
-    addPointToTranscript',
     addCommonScalarToTranscript,
 )
 where
@@ -84,9 +83,9 @@ squeezeChallange bs =
     , bs <> blake2bPrefixChallenge
     )
 
-{-# INLINEABLE addPointToTranscript' #-}
-addPointToTranscript' :: Transcript -> BuiltinBLS12_381_G1_Element -> Transcript
-addPointToTranscript' bs point =
+{-# INLINEABLE addPointToTranscript #-}
+addPointToTranscript :: Transcript -> BuiltinBLS12_381_G1_Element -> Transcript
+addPointToTranscript bs point =
     bs
         <> blake2bPrefixCommon
         <> bls12_381_G1_compress point
@@ -94,10 +93,3 @@ addPointToTranscript' bs point =
 {-# INLINEABLE addScalarToTranscript #-}
 addScalarToTranscript :: Transcript -> Scalar -> Transcript
 addScalarToTranscript bs s = bs <> blake2bPrefixCommon <> (integerToByteString LittleEndian 32 (unScalar s))
-
-{-# INLINEABLE addPointToTranscript #-}
-addPointToTranscript :: Transcript -> BuiltinBLS12_381_G1_Element -> Transcript
-addPointToTranscript bs point =
-    bs
-        <> blake2bPrefixCommon
-        <> bls12_381_G1_compress point

--- a/plutus-verifier/plutus-halo2/test/Benchmarks.hs
+++ b/plutus-verifier/plutus-halo2/test/Benchmarks.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE NoImplicitPrelude #-}
--- use remove-trace for checking performance numbers, use no-remove-trace to see traces
-{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:remove-trace #-}
 
 module Benchmarks (runBenchmarks) where
 
@@ -177,7 +175,7 @@ logResult result = do
     threadDelay 500000
     H.putStrLn "\n    budget consumption (if traces are enabled values are artificially inflated): "
     H.putStrLn H.. T.unpack H.. displayExBudget H.$ evalResultBudget result
-    H.putStrLn "\n    traces (visible if no-remove-trace is set in plutus-verifier/plutus-halo2/test/Benchmarks.hs): "
+    H.putStrLn "\n    traces (visible if tracing code so uncommented): "
     _ <-
         H.sequence
             ( H.map

--- a/src/circuits/atms_circuit.rs
+++ b/src/circuits/atms_circuit.rs
@@ -1,3 +1,5 @@
+use atms_halo2::rescue::{RescueParametersBls, RescueSponge};
+use atms_halo2::signatures::primitive::schnorr::Schnorr;
 use atms_halo2::{
     ecc::chip::EccInstructions,
     instructions::MainGateInstructions,
@@ -5,8 +7,6 @@ use atms_halo2::{
     signatures::schnorr::SchnorrSig,
     util::RegionCtx,
 };
-use atms_halo2::rescue::{RescueParametersBls, RescueSponge};
-use atms_halo2::signatures::primitive::schnorr::Schnorr;
 use blstrs::{Base, JubjubAffine};
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
@@ -160,9 +160,9 @@ pub fn prepare_test_signatures(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use blstrs::Base;
     use ff::Field;
     use halo2_proofs::dev::MockProver;
-    use blstrs::Base;
     use halo2_proofs::plonk::k_from_circuit;
     use rand::SeedableRng;
 

--- a/src/circuits/atms_with_lookups_circuit.rs
+++ b/src/circuits/atms_with_lookups_circuit.rs
@@ -1,7 +1,6 @@
 /// Example circuit implementing ATMS signature verification and a lookup table.
 /// The lookup table does not serve a functional purpose and is included only to evaluate
 /// the complexity of Plutus verification for this type of circuit.
-
 use atms_halo2::{
     ecc::chip::EccInstructions,
     instructions::MainGateInstructions,
@@ -274,13 +273,13 @@ impl Circuit<Base> for AtmsLookupCircuit {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::circuits::atms_circuit::prepare_test_signatures;
+    use blstrs::Base;
     use ff::Field;
     use halo2_proofs::dev::MockProver;
-    use blstrs::Base;
     use halo2_proofs::plonk::k_from_circuit;
-    use rand::prelude::StdRng;
     use rand::SeedableRng;
-    use crate::circuits::atms_circuit::prepare_test_signatures;
+    use rand::prelude::StdRng;
 
     #[test]
     fn test_circuit() {

--- a/src/circuits/lookup_table_circuit.rs
+++ b/src/circuits/lookup_table_circuit.rs
@@ -167,7 +167,11 @@ mod tests {
             native_field: PhantomData,
         };
 
-        let pi = vec![vec![Base::from(42u64), Base::from(42u64), Base::from(42u64)]];
+        let pi = vec![vec![
+            Base::from(42u64),
+            Base::from(42u64),
+            Base::from(42u64),
+        ]];
 
         let k: u32 = k_from_circuit(&circuit);
         let prover =

--- a/src/circuits/mod.rs
+++ b/src/circuits/mod.rs
@@ -1,4 +1,4 @@
-pub mod lookup_table_circuit;
 pub mod atms_circuit;
 pub mod atms_with_lookups_circuit;
+pub mod lookup_table_circuit;
 pub mod simple_mul_circuit;

--- a/src/circuits/simple_mul_circuit.rs
+++ b/src/circuits/simple_mul_circuit.rs
@@ -1,12 +1,10 @@
 /// Simple multiplication example based on the Halo2 book example,
 /// available at: https://zcash.github.io/halo2/user/simple-example.html
-
 use ff::Field;
 use halo2_proofs::circuit::{AssignedCell, Chip, Layouter, Region, SimpleFloorPlanner, Value};
 use halo2_proofs::plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Selector};
 use halo2_proofs::poly::Rotation;
 use std::marker::PhantomData;
-
 
 #[derive(Clone, Debug)]
 pub struct FieldConfig {
@@ -186,11 +184,11 @@ impl<F: Field> Circuit<F> for SimpleMulCircuit<F> {
 
 #[cfg(test)]
 mod tests {
+    use crate::circuits::simple_mul_circuit::SimpleMulCircuit;
     use blstrs::{Base, Scalar};
+    use ff::Field;
     use halo2_proofs::dev::MockProver;
     use halo2_proofs::plonk::k_from_circuit;
-    use ff::Field;
-    use crate::circuits::simple_mul_circuit::SimpleMulCircuit;
 
     #[test]
     fn test_lookup_circuit() {
@@ -202,7 +200,11 @@ mod tests {
 
         let circuit = SimpleMulCircuit::init(constant, a, b, c);
 
-        let pi = vec![vec![Base::from(42u64), Base::from(42u64), Base::from(42u64)]];
+        let pi = vec![vec![
+            Base::from(42u64),
+            Base::from(42u64),
+            Base::from(42u64),
+        ]];
 
         let k: u32 = k_from_circuit(&circuit);
         let prover =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,2 @@
-pub mod plutus_gen;
 pub mod circuits;
+pub mod plutus_gen;

--- a/src/plutus_gen/code_emitters.rs
+++ b/src/plutus_gen/code_emitters.rs
@@ -110,7 +110,9 @@ pub fn emit_verifier_code(
             ProofExtractionSteps::PI => "  !pi_term <- M.readPoint\n".to_string(),
             ProofExtractionSteps::QEvals => section
                 .enumerate()
-                .map(|(number, _permutation_common)| format!("  !q_eval_on_x3_{} <- M.readScalar\n", number + 1))
+                .map(|(number, _permutation_common)| {
+                    format!("  !q_eval_on_x3_{} <- M.readScalar\n", number + 1)
+                })
                 .join(""),
 
             // section for GWC19 version of KZG
@@ -680,11 +682,11 @@ pub fn emit_verifier_code(
             .iter()
             .zip(1..=circuit.permutation_queries.len())
             .map(|(q, idx)| {
-            (
-                format!("permutations_query{}", idx),
-                decode_rotation(&q.point),
-            )
-        })
+                (
+                    format!("permutations_query{}", idx),
+                    decode_rotation(&q.point),
+                )
+            })
             .collect();
 
         let common_queries_traces: Vec<_> = circuit

--- a/src/plutus_gen/extraction/data.rs
+++ b/src/plutus_gen/extraction/data.rs
@@ -36,7 +36,6 @@ pub enum ProofExtractionSteps {
     PI,
     QEvals,
     //
-    
     Theta,
     Beta,
     Gamma,
@@ -70,7 +69,7 @@ pub struct InstantiationSpecificData {
     pub public_inputs_count: usize,
 
     pub w_values_count: usize,
-    
+
     pub q_evaluations_count: usize,
 }
 

--- a/src/plutus_gen/extraction/mod.rs
+++ b/src/plutus_gen/extraction/mod.rs
@@ -98,7 +98,9 @@ impl ExtractKZG for Halo2MultiOpenScheme {
         let (sets, _) = precompute_intermediate_sets(&circuit_representation);
         let number_of_witnesses = sets.len();
 
-        circuit_representation.instantiation_data.q_evaluations_count = number_of_witnesses;
+        circuit_representation
+            .instantiation_data
+            .q_evaluations_count = number_of_witnesses;
         // witnesses
         for _ in 0..number_of_witnesses {
             circuit_representation

--- a/src/plutus_gen/mod.rs
+++ b/src/plutus_gen/mod.rs
@@ -1,5 +1,5 @@
 use crate::plutus_gen::code_emitters::{emit_verifier_code, emit_vk_code};
-use crate::plutus_gen::extraction::{ExtractKZG, extract_circuit, KzgType};
+use crate::plutus_gen::extraction::{ExtractKZG, KzgType, extract_circuit};
 use blstrs::{Bls12, G1Projective, G2Affine, Scalar};
 use halo2_proofs::plonk::VerifyingKey;
 use halo2_proofs::poly::commitment::PolynomialCommitmentScheme;
@@ -29,12 +29,14 @@ pub fn generate_plinth_verifier<S>(
     g2_encoder: fn(G2Affine) -> String,
 ) -> Result<(), String>
 where
-    S: PolynomialCommitmentScheme<Scalar, Commitment=G1Projective> + ExtractKZG,
+    S: PolynomialCommitmentScheme<Scalar, Commitment = G1Projective> + ExtractKZG,
 {
     // static locations of files in plutus directory
     let verifier_template_file = match S::kzg_type() {
         KzgType::GWC19 => Path::new("plutus-verifier/templates/verification_gwc19_kzg.hbs"),
-        KzgType::Halo2MultiOpen => Path::new("plutus-verifier/templates/verification_halo2_kzg.hbs"),
+        KzgType::Halo2MultiOpen => {
+            Path::new("plutus-verifier/templates/verification_halo2_kzg.hbs")
+        }
     };
 
     let vk_template_file = Path::new("plutus-verifier/templates/vk_constants.hbs");
@@ -57,14 +59,14 @@ where
         verifier_generated_file,
         &circuit_representation,
     )
-        .map_err(|e| e.to_string())?;
+    .map_err(|e| e.to_string())?;
     emit_vk_code(
         vk_template_file,
         vk_generated_file,
         &circuit_representation,
         g2_encoder,
     )
-        .map_err(|e| e.to_string())?;
+    .map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src/plutus_gen/proof_serialization.rs
+++ b/src/plutus_gen/proof_serialization.rs
@@ -1,6 +1,6 @@
+use blstrs::Scalar;
 use std::fs::File;
 use std::io::Write;
-use blstrs::Scalar;
 
 pub fn export_proof(proof_file: String, proof: Vec<u8>) -> Result<(), String> {
     let hex = hex::encode(proof);


### PR DESCRIPTION
Replace logic calculating mod inverse on chain with built-in function call

baseline from `main` branch after merging https://github.com/input-output-hk/plutus-halo2-verifier-gen/pull/4
CPU: 5 885 757 108
Memory: 9 693 887
Script size: 7 189

Current status after changes from this PR:
CPU: 3 779 572 604 ~36% reduction
Memory: 1 969 397 ~80% reduction
Script size: 7 137