### PR TITLE
Optimize computation of challenge's powers in Plinth

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,11 @@ variant from Halo2 book):
 
 | Circuit description             | Script size<br/>(% of script limit 14kb) | CPU usage               | Mem usage         |
 |---------------------------------|------------------------------------------|-------------------------|-------------------|
-| **Simple mul**                  | 6551  (45.7%)                            | 3,764,901,258  (37.65%) | 1,745,624 (12.4%) |
-| **Lookup table**                | 11359 (79.2%)                            | 6,585,396,799  (65.85%) | 3,444,710 (24.6%) |
-| **ATMS (50 out of 90)**         | 11947 (83.3%)                            | 7,715,973,120  (77.16%) | 3,485,174 (24.8%) |
-| **ATMS ATMS (228 out of 408)**  | 11947 (83.3%)                            | 7,715,973,120  (77.16%) | 3,485,174 (24.8%) |
-| **ATMS (50/90) + lookup table** | 14242 (99.3%)                            | 9,188,915,328  (91.89%) | 4,692,386 (33.5%) |
+| **Simple mul**                  | 6434  (44.8%)                            | 3,729,441,762  (37.29%) | 1,549,444 (11.0%) |
+| **Lookup table**                | 11250 (78.4%)                            | 6,490,814,414  (64.91%) | 2,915,417 (20.8%) |
+| **ATMS (50 out of 90)**         | 11838 (82.5%)                            | 7,624,238,863  (76.24%) | 2,974,279 (21.2%) |
+| **ATMS (228 out of 408)**       | 11838 (82.5%)                            | 7,624,238,863  (76.24%) | 2,974,279 (21.2%) |
+| **ATMS (50/90) + lookup table** | 14128 (98.5%)                            | 9,043,652,303  (90.44%) | 3,877,297 (27.7%) |
 
 **Note that the benchmark numbers are approximate.** Even for the same circuit, the verifier’s execution cost may vary
 slightly depending on the specific proof being verified. This variation stems from the randomness used during proof

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
@@ -8,7 +8,6 @@ module Plutus.Crypto.Halo2.Halo2MultiOpenMSM (
     computeV,
     evaluateLagrangePolynomials,
     finalCommitment,
-    x1PowersCount,
 ) where
 
 import Plutus.Crypto.BlsTypes (
@@ -62,7 +61,7 @@ import PlutusTx.Prelude (
 -- algorithm is ported from halo2 book
 {-# INLINEABLE buildMSM #-}
 buildMSM ::
-    Scalar ->
+    [Scalar] ->
     Scalar ->
     Scalar ->
     Scalar ->
@@ -72,15 +71,10 @@ buildMSM ::
     [(BuiltinBLS12_381_G1_Element, Integer, [Scalar], [Scalar])] ->
     [[Scalar]] ->
     MSM
-buildMSM x1 x2 x3 x4 f_comm pi_commitment proofX3QEvals commitmentMap pointSets = right
+buildMSM x1Powers x2 x3 x4 f_comm pi_commitment proofX3QEvals commitmentMap pointSets = right
   where
     pointSetsIndexes :: [Integer]
     pointSetsIndexes = enumFromTo 0 (length pointSets - 1)
-
-    -- x1Powers length can be precomputed
-    -- todo length can be precomputed
-    x1Powers :: [Scalar]
-    x1Powers = powers (x1PowersCount pointSetsIndexes commitmentMap) x1
 
     (q_coms, q_eval_sets) = unzip (buildQ commitmentMap pointSetsIndexes x1Powers)
 
@@ -161,22 +155,6 @@ evaluateLagrangePolynomials pointSets q_eval_sets x2 x3 proofX3QEvals =
         zero
         (reverse (zip (zip pointSets q_eval_sets) proofX3QEvals))
 
-{-# INLINEABLE x1PowersCount #-}
-x1PowersCount :: [Integer] -> [(BuiltinBLS12_381_G1_Element, Integer, [Scalar], [Scalar])] -> Integer
-x1PowersCount pointSetsIndexes commitmentMap =
-    foldl
-        max
-        0
-        ( map
-            ( \idx ->
-                length
-                    ( filter
-                        (\(_, set_index, _, _) -> set_index == idx)
-                        commitmentMap
-                    )
-            )
-            pointSetsIndexes
-        )
 
 {-# INLINEABLE buildQ #-}
 buildQ ::

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
@@ -14,9 +14,6 @@ import Plutus.Crypto.BlsTypes (
     Scalar,
     recip,
  )
-import Plutus.Crypto.BlsUtils (
-    powers,
- )
 import Plutus.Crypto.Halo2.LagrangePolynomialEvaluation (
     lagrangeEvaluation,
  )
@@ -46,7 +43,6 @@ import PlutusTx.Prelude (
     bls12_381_G1_neg,
     bls12_381_G1_uncompress,
     enumFromTo,
-    max,
     one,
 --    trace,
     zero,

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
@@ -56,32 +56,28 @@ import PlutusTx.Prelude (
     (==),
  )
 
--- this function takes commitment with point sets and returns only right MSM for further evaluation
--- as left MSM is equal to ONE * PI commitment
--- algorithm is ported from halo2 book
+-- Prepares MSM for multi-open KZG polynomial commitment verification.
+-- When evaluated, it represents the `right` input of the pairing check equation: `e(left, sG2) == e(right, G2)`,
+-- where left = PI commitment.
+-- For reference, see `https://github.com/input-output-hk/halo2/blob/plutus_verification/src/poly/kzg/mod.rs#L193`
 {-# INLINEABLE buildMSM #-}
 buildMSM ::
     [Scalar] ->
     Scalar ->
     Scalar ->
-    Scalar ->
+    [Scalar] ->
     BuiltinBLS12_381_G1_Element ->
     BuiltinBLS12_381_G1_Element ->
     [Scalar] ->
     [(BuiltinBLS12_381_G1_Element, Integer, [Scalar], [Scalar])] ->
     [[Scalar]] ->
     MSM
-buildMSM x1Powers x2 x3 x4 f_comm pi_commitment proofX3QEvals commitmentMap pointSets = right
+buildMSM x1Powers x2 x3 x4Powers f_comm pi_commitment proofX3QEvals commitmentMap pointSets = right
   where
     pointSetsIndexes :: [Integer]
     pointSetsIndexes = enumFromTo 0 (length pointSets - 1)
 
     (q_coms, q_eval_sets) = unzip (buildQ commitmentMap pointSetsIndexes x1Powers)
-
-    x4PowersCount = length pointSets + 1
-
-    x4Powers :: [Scalar]
-    x4Powers = powers x4PowersCount x4
 
     f_eval :: Scalar
     f_eval = evaluateLagrangePolynomials pointSets q_eval_sets x2 x3 proofX3QEvals

--- a/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
+++ b/plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Halo2MultiOpenMSM.hs
@@ -78,8 +78,7 @@ buildMSM x1Powers x2 x3 x4 f_comm pi_commitment proofX3QEvals commitmentMap poin
 
     (q_coms, q_eval_sets) = unzip (buildQ commitmentMap pointSetsIndexes x1Powers)
 
-    -- todo length can be precomputed
-    x4PowersCount = (max (length proofX3QEvals + 1) (length q_coms + 1))
+    x4PowersCount = length pointSets + 1
 
     x4Powers :: [Scalar]
     x4Powers = powers x4PowersCount x4

--- a/plutus-verifier/templates/verification_halo2_kzg.hbs
+++ b/plutus-verifier/templates/verification_halo2_kzg.hbs
@@ -91,9 +91,6 @@ barycentricWeight = $(lift VKConstants.barycentricWeight_val)
 s_g2 :: BuiltinBLS12_381_G2_Element
 s_g2 = $(lift VKConstants.s_g2_val)
 
-x1PowersCount :: Integer
-x1PowersCount = {{{X1_POWERS_COUNT}}}
-
 {{{FIXED_COMMITMENT_LIFTS}}}
 
 {{{PERMUTATION_COMMITMENT_LIFTS}}}
@@ -193,14 +190,15 @@ verify proof {{{PUBLIC_INPUTS_NAMES}}} = fst $ flip (M.run VKConstants.transcrip
       -- g2 is not negated as bls12_381_finalVerify is doing negation
       !g2 = (bls12_381_G2_uncompress bls12_381_G2_compressed_generator)
 
-      !x1Powers = BlsUtils.powers x1PowersCount x1
+      !x1Powers = BlsUtils.powers {{{X1_POWERS_COUNT}}} x1
+      !x4Powers = BlsUtils.powers {{{X4_POWERS_COUNT}}} x4
 
       !alt_right =
           buildMSM
               x1Powers
               x2
               x3
-              x4
+              x4Powers
               f_commitment
               pi_term
               [{{{Q_EVALS_FROM_PROOF}}}]

--- a/plutus-verifier/templates/verification_halo2_kzg.hbs
+++ b/plutus-verifier/templates/verification_halo2_kzg.hbs
@@ -91,6 +91,9 @@ barycentricWeight = $(lift VKConstants.barycentricWeight_val)
 s_g2 :: BuiltinBLS12_381_G2_Element
 s_g2 = $(lift VKConstants.s_g2_val)
 
+x1PowersCount :: Integer
+x1PowersCount = {{{X1_POWERS_COUNT}}}
+
 {{{FIXED_COMMITMENT_LIFTS}}}
 
 {{{PERMUTATION_COMMITMENT_LIFTS}}}
@@ -190,9 +193,11 @@ verify proof {{{PUBLIC_INPUTS_NAMES}}} = fst $ flip (M.run VKConstants.transcrip
       -- g2 is not negated as bls12_381_finalVerify is doing negation
       !g2 = (bls12_381_G2_uncompress bls12_381_G2_compressed_generator)
 
+      !x1Powers = BlsUtils.powers x1PowersCount x1
+
       !alt_right =
           buildMSM
-              x1
+              x1Powers
               x2
               x3
               x4

--- a/plutus-verifier/templates/vk_constants.hbs
+++ b/plutus-verifier/templates/vk_constants.hbs
@@ -27,14 +27,10 @@ import PlutusTx.Prelude (
   BuiltinBLS12_381_G2_Element,
   bls12_381_G1_compressed_zero,
   bls12_381_G1_uncompress,
+  bls12_381_G2_uncompress,
+  BuiltinByteString,
   modulo,
  )
-
-import PlutusTx.Prelude (
-  BuiltinByteString,
-  bls12_381_G2_uncompress
- )
-
 import PlutusTx.Builtins.HasOpaque (
   stringToBuiltinByteStringHex,
  )

--- a/src/plutus_gen/code_emitters.rs
+++ b/src/plutus_gen/code_emitters.rs
@@ -430,6 +430,24 @@ pub fn emit_verifier_code(
 
     let (unique_grouped_points, commitment_data) = precompute_intermediate_sets(circuit);
 
+    // Precompute maximum number of commitments queried for any points set,
+    // it will define the number of X1 powers that we would need to compute during verification
+    let point_sets_indexes: Vec<usize> = (0..unique_grouped_points.len()).collect();
+    let max_commitments_per_points_set = point_sets_indexes
+        .iter()
+        .map(|&idx| {
+            commitment_data
+                .iter()
+                .filter(|cd| cd.point_set_index == idx)
+                .count()
+        })
+        .max()
+        .unwrap_or(0);
+    data.insert(
+        "X1_POWERS_COUNT".to_string(),
+        max_commitments_per_points_set.to_string(),
+    );
+
     let commitment_data = commitment_data
         .iter()
         .map(|commitment_data| {

--- a/src/plutus_gen/code_emitters.rs
+++ b/src/plutus_gen/code_emitters.rs
@@ -448,6 +448,11 @@ pub fn emit_verifier_code(
         max_commitments_per_points_set.to_string(),
     );
 
+    data.insert(
+        "X4_POWERS_COUNT".to_string(),
+        (point_sets_indexes.len() + 1).to_string(),
+    );
+
     let commitment_data = commitment_data
         .iter()
         .map(|commitment_data| {

--- a/src/plutus_gen/extraction/data.rs
+++ b/src/plutus_gen/extraction/data.rs
@@ -21,13 +21,12 @@ pub enum ProofExtractionSteps {
     XCoordinate,
     YCoordinate,
 
-    // elements specific to legacy GWC
+    // elements specific to GWC19 version of multiopen KZG
     V,
     U,
     Witnesses,
-    //
 
-    //elements related to multi open GWC
+    //elements related to Halo2 version of multiopen KZG
     X1,
     X2,
     X3,


### PR DESCRIPTION
x1PowersCount and x4PowersCount are static for the circuit. Instead of calculating them in on-chain script, we now precompute them during Plinth code generation. It saves ~15% of MEM usage and a few % of CPU and script size.