### PR TITLE
Expose transitive dependencies so it is easier to use this repo as a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,8 @@ pub use atms_halo2::{
     rescue::{RescueParametersBls, RescueSponge},
     signatures::{primitive::schnorr::Schnorr, schnorr::SchnorrSig},
 };
-pub use halo2_proofs::plonk::prepare;
 pub use halo2_proofs::{
-    plonk::{ProvingKey, VerifyingKey, create_proof, k_from_circuit, keygen_pk, keygen_vk},
-    poly::{gwc_kzg::GwcKZGCommitmentScheme, kzg::params::ParamsKZG},
+    plonk::{ProvingKey, VerifyingKey, create_proof, k_from_circuit, keygen_pk, keygen_vk,prepare},
+    poly::{gwc_kzg::GwcKZGCommitmentScheme, kzg::params::ParamsKZG, commitment::Guard},
     transcript::{CircuitTranscript, Transcript},
 };


### PR DESCRIPTION
This PR exposes some types from transitive dependencies so when you use it as a library you do not have to have those dependencies in your project