### PR TITLE
Update the error handling in the `aiken-verifier` CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand_core = { package = "rand_core", version = "0.6.4" }
 serde = { version = "1.0.219", features = ["derive"] }
 rand = "0.8"
 rand_chacha = "0.3.1"
+anyhow = "1.0.100"
 
 [features]
 plutus_debug = ["halo2_proofs/plutus_debug"]

--- a/aiken-verifier/Cargo.toml
+++ b/aiken-verifier/Cargo.toml
@@ -14,3 +14,4 @@ log = "0.4.28"
 reqwest = { version = "0.12.12", features = ["json"] }
 tokio = { version = "1.47.1", features = ["full"] }
 env_logger = "0.5.10"
+anyhow = "1.0.100"

--- a/examples/atms.rs
+++ b/examples/atms.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context as _, Result, anyhow, bail};
 use blstrs::{Base, Bls12, G1Projective, Scalar};
 use halo2_proofs::{
     plonk::{
@@ -11,6 +12,7 @@ use halo2_proofs::{
 };
 use log::info;
 use plutus_halo2_verifier_gen::plutus_gen::extraction::ExtractKZG;
+use plutus_halo2_verifier_gen::plutus_gen::generate_aiken_verifier;
 use plutus_halo2_verifier_gen::{
     circuits::atms_circuit::{AtmsSignatureCircuit, prepare_test_signatures},
     plutus_gen::{
@@ -22,18 +24,15 @@ use rand::prelude::StdRng;
 use rand_core::SeedableRng;
 use std::env;
 use std::fs::File;
-use plutus_halo2_verifier_gen::plutus_gen::generate_aiken_verifier;
 
-fn main() {
+fn main() -> Result<()> {
     env_logger::init_from_env(env_logger::Env::default().filter_or("RUST_LOG", "info"));
     let args: Vec<String> = env::args().collect();
 
     match &args[1..] {
-        [] => {
-            compile_atms_circuit::<KZGCommitmentScheme<Bls12>>();
-        }
+        [] => compile_atms_circuit::<KZGCommitmentScheme<Bls12>>(),
         [command] if command == "gwc_kzg" => {
-            compile_atms_circuit::<GwcKZGCommitmentScheme<Bls12>>();
+            compile_atms_circuit::<GwcKZGCommitmentScheme<Bls12>>()
         }
         _ => {
             println!("Usage:");
@@ -41,6 +40,8 @@ fn main() {
             println!(
                 "- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`"
             );
+
+            bail!("Invalid command line arguments")
         }
     }
 }
@@ -52,7 +53,7 @@ pub fn compile_atms_circuit<
             Parameters = ParamsKZG<Bls12>,
             VerifierParameters = ParamsVerifierKZG<Bls12>,
         > + ExtractKZG,
->() {
+>() -> Result<()> {
     let seed = [0u8; 32]; // UNSAFE, constant seed is used for testing purposes
     let mut rng: StdRng = SeedableRng::from_seed(seed);
 
@@ -82,8 +83,8 @@ pub fn compile_atms_circuit<
 
     let instances_file =
         "./plutus-verifier/plutus-halo2/test/Generic/serialized_public_input.hex".to_string();
-    let mut output = File::create(instances_file).expect("failed to create instances file");
-    export_public_inputs(instances, &mut output);
+    let mut output = File::create(instances_file).context("failed to create instances file")?;
+    export_public_inputs(instances, &mut output).context("Failed to export the public inputs")?;
 
     let mut transcript: CircuitTranscript<CardanoFriendlyState> =
         CircuitTranscript::<CardanoFriendlyState>::init();
@@ -96,7 +97,7 @@ pub fn compile_atms_circuit<
         &mut rng,
         &mut transcript,
     )
-    .expect("proof generation should not fail");
+    .context("proof generation should not fail")?;
 
     let proof = transcript.finalize();
     info!("proof size {:?}", proof.len());
@@ -109,21 +110,24 @@ pub fn compile_atms_circuit<
         instances,
         &mut transcript_verifier,
     )
-    .expect("prepare verification failed");
+    .context("prepare verification failed")?;
 
     verifier
         .verify(&kzg_params.verifier_params())
-        .expect("verify failed");
+        .map_err(|e| anyhow!("{e:?}"))
+        .context("verify failed")?;
 
     serialize_proof(
         "./plutus-verifier/plutus-halo2/test/Generic/serialized_proof.json".to_string(),
         proof.clone(),
     )
-    .expect("json proof serialization failed");
+    .context("json proof serialization failed")?;
 
     generate_plinth_verifier(&kzg_params, &vk, instances)
-        .expect("Plinth verifier generation failed");
+        .context("Plinth verifier generation failed")?;
 
     generate_aiken_verifier(&kzg_params, &vk, instances, Some(proof))
-        .expect("Aiken verifier generation failed");
+        .context("Aiken verifier generation failed")?;
+
+    Ok(())
 }

--- a/examples/lookup_table.rs
+++ b/examples/lookup_table.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context as _, Result, anyhow, bail};
 use blstrs::{Base, Bls12, G1Projective, Scalar};
 use halo2_proofs::{
     plonk::{
@@ -23,16 +24,14 @@ use std::env;
 use std::fs::File;
 use std::marker::PhantomData;
 
-fn main() {
+fn main() -> Result<()> {
     env_logger::init_from_env(env_logger::Env::default().filter_or("RUST_LOG", "info"));
     let args: Vec<String> = env::args().collect();
 
     match &args[1..] {
-        [] => {
-            compile_lookup_table_circuit::<KZGCommitmentScheme<Bls12>>();
-        }
+        [] => compile_lookup_table_circuit::<KZGCommitmentScheme<Bls12>>(),
         [command] if command == "gwc_kzg" => {
-            compile_lookup_table_circuit::<GwcKZGCommitmentScheme<Bls12>>();
+            compile_lookup_table_circuit::<GwcKZGCommitmentScheme<Bls12>>()
         }
         _ => {
             println!("Usage:");
@@ -40,6 +39,8 @@ fn main() {
             println!(
                 "- to run the example using the GWC19 version of multi-open KZG, run: `cargo run --example example_name gwc_kzg`"
             );
+
+            bail!("Invalid command line arguments")
         }
     }
 }
@@ -51,7 +52,7 @@ pub fn compile_lookup_table_circuit<
             Parameters = ParamsKZG<Bls12>,
             VerifierParameters = ParamsVerifierKZG<Bls12>,
         > + ExtractKZG,
->() {
+>() -> Result<()> {
     let seed = [0u8; 32]; // UNSAFE, constant seed is used for testing purposes
     let mut rng: StdRng = SeedableRng::from_seed(seed);
 
@@ -73,8 +74,8 @@ pub fn compile_lookup_table_circuit<
 
     let instances_file =
         "./plutus-verifier/plutus-halo2/test/Generic/serialized_public_input.hex".to_string();
-    let mut output = File::create(instances_file).expect("failed to create instances file");
-    export_public_inputs(instances, &mut output);
+    let mut output = File::create(instances_file).context("failed to create instances file")?;
+    export_public_inputs(instances, &mut output).context("Failed to export public inputs")?;
 
     let mut transcript: CircuitTranscript<CardanoFriendlyState> =
         CircuitTranscript::<CardanoFriendlyState>::init();
@@ -87,7 +88,7 @@ pub fn compile_lookup_table_circuit<
         &mut rng,
         &mut transcript,
     )
-    .expect("proof generation should not fail");
+    .context("proof generation should not fail")?;
 
     let proof = transcript.finalize();
 
@@ -101,18 +102,21 @@ pub fn compile_lookup_table_circuit<
         instances,
         &mut transcript_verifier,
     )
-    .expect("prepare verification failed");
+    .context("prepare verification failed")?;
 
     verifier
         .verify(&kzg_params.verifier_params())
-        .expect("verify failed");
+        .map_err(|e| anyhow!("{e:?}"))
+        .context("verify failed")?;
 
     serialize_proof(
         "./plutus-verifier/plutus-halo2/test/Generic/serialized_proof.json".to_string(),
         proof,
     )
-    .expect("json proof serialization failed");
+    .context("json proof serialization failed")?;
 
     generate_plinth_verifier(&kzg_params, &vk, instances)
-        .expect("Plinth verifier generation failed");
+        .context("Plinth verifier generation failed")?;
+
+    Ok(())
 }

--- a/src/plutus_gen/mod.rs
+++ b/src/plutus_gen/mod.rs
@@ -6,6 +6,7 @@ use crate::plutus_gen::code_emitters_plutus::{
 };
 use crate::plutus_gen::extraction::data::RotationDescription;
 use crate::plutus_gen::extraction::{ExtractKZG, KzgType, extract_circuit};
+use anyhow::{Context as _, Result};
 use blstrs::{Bls12, G1Projective, Scalar};
 use halo2_proofs::plonk::VerifyingKey;
 use halo2_proofs::poly::commitment::PolynomialCommitmentScheme;
@@ -33,7 +34,7 @@ pub fn generate_plinth_verifier<S>(
     params: &ParamsKZG<Bls12>,
     vk: &VerifyingKey<Scalar, S>,
     instances: &[&[&[Scalar]]],
-) -> Result<(), String>
+) -> Result<()>
 where
     S: PolynomialCommitmentScheme<Scalar, Commitment = G1Projective> + ExtractKZG,
 {
@@ -52,8 +53,8 @@ where
         Path::new("plutus-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Generic/VKConstants.hs");
 
     // Step 1: extract circuit representation
-    let circuit_representation =
-        extract_circuit(params, vk, instances).map_err(|e| e.to_string())?;
+    let circuit_representation = extract_circuit(params, vk, instances)
+        .context("Failed to extract the circuit representation")?;
 
     // Step 2: extract KZG steps specific to used commitment scheme
     let circuit_representation = S::extract_kzg_steps(circuit_representation);
@@ -65,9 +66,9 @@ where
         verifier_generated_file,
         &circuit_representation,
     )
-    .map_err(|e| e.to_string())?;
+    .context("Failed to emit the verifier code for plutus")?;
     emit_vk_code(vk_template_file, vk_generated_file, &circuit_representation)
-        .map_err(|e| e.to_string())?;
+        .context("Failed to emit the verifier key constants")?;
 
     Ok(())
 }
@@ -77,12 +78,12 @@ pub fn generate_aiken_verifier<S>(
     vk: &VerifyingKey<Scalar, S>,
     instances: &[&[&[Scalar]]],
     test_proof: Option<Vec<u8>>,
-) -> Result<(), String>
+) -> Result<()>
 where
     S: PolynomialCommitmentScheme<Scalar, Commitment = G1Projective> + ExtractKZG,
 {
-    let circuit_representation =
-        extract_circuit(params, vk, instances).map_err(|e| e.to_string())?;
+    let circuit_representation = extract_circuit(params, vk, instances)
+        .context("Failed to extract the circuit representation")?;
     let circuit_representation = S::extract_kzg_steps(circuit_representation);
 
     emit_verifier_code_aiken(
@@ -91,13 +92,13 @@ where
         &circuit_representation,
         test_proof.map(|p| (p, vk.transcript_repr(), instances[0][0].to_vec())),
     )
-    .map_err(|e| e.to_string())?;
+    .context("Failed to emit the verifier code for aiken")?;
     emit_vk_code_aiken(
         Path::new("aiken-verifier/templates/vk_constants.hbs"),
         Path::new("aiken-verifier/aiken_halo2/lib/verifier_key.ak"),
         &circuit_representation,
     )
-    .map_err(|e| e.to_string())?;
+    .context("Failed to emit the verifier key constants for aiken")?;
 
     Ok(())
 }

--- a/src/plutus_gen/proof_serialization.rs
+++ b/src/plutus_gen/proof_serialization.rs
@@ -1,25 +1,46 @@
+use anyhow::{Context as _, Result, anyhow};
 use blstrs::Scalar;
 use std::fs::File;
 use std::io::Write;
 
-pub fn export_proof(proof_file: String, proof: Vec<u8>) -> Result<(), String> {
+pub fn export_proof(proof_file: String, proof: Vec<u8>) -> Result<()> {
     let hex = hex::encode(proof);
-    let mut output = File::create(proof_file).map_err(|e| e.to_string())?;
-    let _ = output.write(hex.as_bytes());
+
+    let mut output = File::create(&proof_file)
+        .with_context(|| anyhow!("Failed to create file `{proof_file}'"))?;
+    output
+        .write(hex.as_bytes())
+        .with_context(|| anyhow!("Failed to write proof to file `{proof_file}'"))?;
+    output
+        .flush()
+        .with_context(|| anyhow!("Failed to flush to file `{proof_file}'"))?;
+
     Ok(())
 }
 
-pub fn serialize_proof(proof_file: String, proof: Vec<u8>) -> Result<(), String> {
-    let serialized_proof = serde_json::to_string(&proof).map_err(|e| e.to_string())?;
-    let mut output = File::create(proof_file).map_err(|e| e.to_string())?;
-    let _ = output.write(serialized_proof.as_bytes());
+pub fn serialize_proof(proof_file: String, proof: Vec<u8>) -> Result<()> {
+    let serialized_proof = serde_json::to_string(&proof)
+        .with_context(|| anyhow!("Failed to serialise Proof for `{proof_file}'"))?;
+
+    let mut output = File::create(&proof_file)
+        .with_context(|| anyhow!("Failed to create file `{proof_file}'"))?;
+    output
+        .write(serialized_proof.as_bytes())
+        .with_context(|| anyhow!("Failed to write proof to file `{proof_file}'"))?;
+    output
+        .flush()
+        .with_context(|| anyhow!("Failed to flush to file `{proof_file}'"))?;
     Ok(())
 }
 
-pub fn export_public_inputs(instances: &[&[&[Scalar]]], output: &mut File) {
+pub fn export_public_inputs(instances: &[&[&[Scalar]]], output: &mut File) -> Result<()> {
     for instance in instances[0][0].iter() {
         let mut value = instance.to_bytes_le();
         value.reverse();
-        let _ = output.write((hex::encode(value) + "\n").as_bytes());
+        output
+            .write((hex::encode(value) + "\n").as_bytes())
+            .context("Failed to write encoded scalar to the output file")?;
     }
+
+    Ok(())
 }


### PR DESCRIPTION
This allows to go from an error message to look like this:

```
thread 'main' (9280059) panicked at src/api.rs:183:14:
Failed to read .env file: Io(Custom { kind: NotFound, error: "path not found" })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

To an error message that looks like this:

```
Error: Failed to load necessary environment variables

Caused by:
    0: Failed to read .env file
    1: path not found
    2: path not found
```

Now the load_env function does not report a useful error and maybe it should be handled differently. But this is not the point of this PR.