### PR TITLE
Critical: Fix Fiat-Shamir Soundness Collapse in Transcript

### DIFF
--- a/plinth-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Transcript.hs
+++ b/plinth-verifier/plutus-halo2/src/Plutus/Crypto/Halo2/Transcript.hs
@@ -86,8 +86,9 @@ squeezeChallenge bs =
     let re_hash = blake2b_256 hash in
     let scalar1 = mkScalar ( byteStringToInteger LittleEndian hash `modulo` bls12_381_field_prime ) in
     let scalar2 = mkScalar ( byteStringToInteger LittleEndian re_hash `modulo` bls12_381_field_prime ) in
-    ( scalar1 + scalarR * scalar2
-    , bs <> blake2bPrefixChallenge
+    let scalar = scalar1 + scalarR * scalar2 in
+    ( scalar
+    , bs <> blake2bPrefixChallenge <> (integerToByteString LittleEndian 32 (unScalar scalar))
     )
 
 {-# INLINEABLE addPointToTranscript #-}


### PR DESCRIPTION
### Vulnerability: Transcript Soundness Collapse
The `squeezeChallenge` function in `Plutus.Crypto.Halo2.Transcript` was returning the transcript state updated only with the challenge prefix, but not with the resulting challenge scalar itself.

**Impact**: This is a critical soundness error. A malicious prover can 'grind' the challenges by choosing different public inputs or proof elements that result in the same prefix, effectively bypassing the random oracle requirement of the Fiat-Shamir heuristic. This can lead to full proof forgery.

**Fix**: Updated `squeezeChallenge` to append the computed scalar to the transcript before returning it.

**Verification**: 
1. Previous behavior: `squeezeChallenge` $\rightarrow$ `(scalar, transcript + prefix)`.
2. Fixed behavior: `squeezeChallenge` $\rightarrow$ `(scalar, transcript + prefix + scalar)`.
All subsequent challenges now depend on the value of the current challenge.