### PR TITLE
Adding extra chips to cost estimator

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ Chips (combine as needed):
   --bls12-381       BLS12-381 curve chip
   --curve25519      Curve25519 curve chip
   --secp256k1       Secp256k1 curve chip
+  --secp256r1       Secp256r1 curve chip
   --hash-to-curve   Poseidon hash-to-Jubjub-curve chip
 
 Circuit config (all default to 0):

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sh <(curl -L https://nixos.org/nix/install)
 substituters = https://cache.nixos.org https://cache.iog.io
 trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 experimental-features = nix-command flakes
-allow-import-from-derivation = "true"
+allow-import-from-derivation = true
 ```
 
 3. The contract can be build from the relevant templates folder using the nix shell:
@@ -78,6 +78,7 @@ allow-import-from-derivation = "true"
 ```bash
 nix develop github:input-output-hk/devx#ghc96-iog
 cd plinth-verifier
+cabal update
 cabal build -j all
 cabal test all
 ```

--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ Proof inputs :
 
 Chips (combine as needed):
   --native          Native arithmetic chip (arithmetic + parallel_add gates)
+  --automaton       Regular expression parsing (automaton) chip
+  --base64          Base64 decoding chip
   --sha256          SHA256 hash chip
   --sha512          SHA512 hash chip
   --poseidon        Poseidon hash chip

--- a/docs/chip_profiles.json
+++ b/docs/chip_profiles.json
@@ -1,4 +1,174 @@
 {
+  "automaton": {
+    "deps": [
+      "native"
+    ],
+    "degree": 5,
+    "advice_cols": 6,
+    "fixed_cols": 14,
+    "copy_constraints": 7,
+    "nb_lookup_tables": 1,
+    "gates": 3,
+    "gate_expressions": 5,
+    "lookups": 8,
+    "trash": 0,
+    "proof_commitments": 22,
+    "vk_commitments": 21,
+    "evals": 50,
+    "gate_ops": {
+      "neg": 5,
+      "add": 19,
+      "sub": 0,
+      "mul": 17,
+      "from_int": 0
+    },
+    "lookup_ops": {
+      "neg": 0,
+      "add": 6,
+      "sub": 0,
+      "mul": 14,
+      "from_int": 0
+    },
+    "trash_ops": {
+      "neg": 0,
+      "add": 0,
+      "sub": 0,
+      "mul": 0,
+      "from_int": 0
+    },
+    "commitment_map": [
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        3,
+        3
+      ],
+      [
+        2,
+        2
+      ]
+    ],
+    "proof_size": 2656,
+    "vk_size": 1018
+  },
+  "base64": {
+    "deps": [
+      "native"
+    ],
+    "degree": 5,
+    "advice_cols": 5,
+    "fixed_cols": 14,
+    "copy_constraints": 6,
+    "nb_lookup_tables": 1,
+    "gates": 3,
+    "gate_expressions": 5,
+    "lookups": 2,
+    "trash": 0,
+    "proof_commitments": 17,
+    "vk_commitments": 20,
+    "evals": 40,
+    "gate_ops": {
+      "neg": 5,
+      "add": 19,
+      "sub": 0,
+      "mul": 17,
+      "from_int": 0
+    },
+    "lookup_ops": {
+      "neg": 1,
+      "add": 4,
+      "sub": 0,
+      "mul": 5,
+      "from_int": 3
+    },
+    "trash_ops": {
+      "neg": 0,
+      "add": 0,
+      "sub": 0,
+      "mul": 0,
+      "from_int": 0
+    },
+    "commitment_map": [
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        3
+      ],
+      [
+        2
+      ]
+    ],
+    "proof_size": 2096,
+    "vk_size": 970
+  },
   "bls12381": {
     "deps": [
       "native"
@@ -9,9 +179,12 @@
     "copy_constraints": 16,
     "nb_lookup_tables": 0,
     "gates": 9,
-    "lookups": 1,
+    "gate_expressions": 23,
+    "lookups": 16,
     "trash": 0,
-    "evals": 36,
+    "proof_commitments": 31,
+    "vk_commitments": 37,
+    "evals": 80,
     "gate_ops": {
       "neg": 80,
       "add": 1431,
@@ -121,9 +294,12 @@
     "copy_constraints": 11,
     "nb_lookup_tables": 0,
     "gates": 8,
-    "lookups": 1,
+    "gate_expressions": 15,
+    "lookups": 10,
     "trash": 0,
-    "evals": 30,
+    "proof_commitments": 24,
+    "vk_commitments": 31,
+    "evals": 63,
     "gate_ops": {
       "neg": 42,
       "add": 255,
@@ -222,9 +398,12 @@
     "copy_constraints": 8,
     "nb_lookup_tables": 0,
     "gates": 7,
+    "gate_expressions": 18,
     "lookups": 0,
-    "trash": 1,
-    "evals": 27,
+    "trash": 8,
+    "proof_commitments": 20,
+    "vk_commitments": 26,
+    "evals": 48,
     "gate_ops": {
       "neg": 23,
       "add": 64,
@@ -308,9 +487,12 @@
     "copy_constraints": 8,
     "nb_lookup_tables": 0,
     "gates": 6,
+    "gate_expressions": 12,
     "lookups": 0,
     "trash": 0,
-    "evals": 25,
+    "proof_commitments": 19,
+    "vk_commitments": 24,
+    "evals": 45,
     "gate_ops": {
       "neg": 17,
       "add": 44,
@@ -389,9 +571,12 @@
     "copy_constraints": 6,
     "nb_lookup_tables": 0,
     "gates": 3,
+    "gate_expressions": 5,
     "lookups": 0,
     "trash": 0,
-    "evals": 18,
+    "proof_commitments": 14,
+    "vk_commitments": 19,
+    "evals": 36,
     "gate_ops": {
       "neg": 5,
       "add": 19,
@@ -463,9 +648,12 @@
     "copy_constraints": 6,
     "nb_lookup_tables": 0,
     "gates": 4,
+    "gate_expressions": 11,
     "lookups": 0,
-    "trash": 1,
-    "evals": 23,
+    "trash": 8,
+    "proof_commitments": 18,
+    "vk_commitments": 21,
+    "evals": 39,
     "gate_ops": {
       "neg": 11,
       "add": 39,
@@ -542,9 +730,12 @@
     "copy_constraints": 10,
     "nb_lookup_tables": 0,
     "gates": 11,
-    "lookups": 1,
+    "gate_expressions": 22,
+    "lookups": 10,
     "trash": 0,
-    "evals": 32,
+    "proof_commitments": 23,
+    "vk_commitments": 33,
+    "evals": 64,
     "gate_ops": {
       "neg": 67,
       "add": 476,
@@ -642,9 +833,12 @@
     "copy_constraints": 10,
     "nb_lookup_tables": 0,
     "gates": 11,
-    "lookups": 1,
+    "gate_expressions": 27,
+    "lookups": 10,
     "trash": 0,
-    "evals": 32,
+    "proof_commitments": 23,
+    "vk_commitments": 33,
+    "evals": 64,
     "gate_ops": {
       "neg": 91,
       "add": 705,
@@ -742,9 +936,12 @@
     "copy_constraints": 7,
     "nb_lookup_tables": 1,
     "gates": 14,
-    "lookups": 2,
+    "gate_expressions": 22,
+    "lookups": 6,
     "trash": 0,
-    "evals": 33,
+    "proof_commitments": 24,
+    "vk_commitments": 32,
+    "evals": 64,
     "gate_ops": {
       "neg": 22,
       "add": 173,
@@ -842,9 +1039,12 @@
     "copy_constraints": 7,
     "nb_lookup_tables": 1,
     "gates": 14,
-    "lookups": 2,
+    "gate_expressions": 22,
+    "lookups": 6,
     "trash": 0,
-    "evals": 33,
+    "proof_commitments": 24,
+    "vk_commitments": 32,
+    "evals": 66,
     "gate_ops": {
       "neg": 22,
       "add": 237,

--- a/docs/chip_profiles.json
+++ b/docs/chip_profiles.json
@@ -632,6 +632,106 @@
     "proof_size": 3152,
     "vk_size": 1594
   },
+  "secp256r1": {
+    "deps": [
+      "native"
+    ],
+    "degree": 5,
+    "advice_cols": 9,
+    "fixed_cols": 23,
+    "copy_constraints": 10,
+    "nb_lookup_tables": 0,
+    "gates": 11,
+    "lookups": 1,
+    "trash": 0,
+    "evals": 32,
+    "gate_ops": {
+      "neg": 91,
+      "add": 705,
+      "sub": 0,
+      "mul": 989,
+      "from_int": 614
+    },
+    "lookup_ops": {
+      "neg": 10,
+      "add": 19,
+      "sub": 0,
+      "mul": 19,
+      "from_int": 10
+    },
+    "trash_ops": {
+      "neg": 0,
+      "add": 0,
+      "sub": 0,
+      "mul": 0,
+      "from_int": 0
+    },
+    "commitment_map": [
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1
+      ],
+      [
+        2,
+        2
+      ],
+      [
+        3,
+        3,
+        3
+      ],
+      [
+        2
+      ],
+      [
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3
+      ]
+    ],
+    "proof_size": 3152,
+    "vk_size": 1594
+  },
   "sha256": {
     "deps": [
       "native"

--- a/docs/chips.html
+++ b/docs/chips.html
@@ -106,9 +106,18 @@
     .cmp-table-cmp { table-layout: fixed; }
     .cmp-table-cmp .th-chip  { width: 130px; }
     .cmp-table-cmp .th-dep   { width: 200px; text-align: left !important; }
-    .cmp-table-cmp .th-stat  { width: 68px; }
-    .cmp-table-cmp .th-size  { width: 82px; }
+    .cmp-table-cmp .th-stat  { width: 80px; }
+    .cmp-table-cmp .th-size  { width: 92px; }
+    .cmp-table-cmp th { white-space: normal; line-height: 1.3; }
     .cmp-table-cmp td.td-deps { text-align: left; font-size: 11px; color: var(--muted); }
+    .cmp-table-deps { width: auto; max-width: 420px; margin: 0 auto; }
+    .cmp-table-deps th, .cmp-table-deps td { padding: 6px 12px; font-size: 12px; }
+    .cmp-table-deps .th-chip { width: 100px; }
+    .cmp-table-deps .th-dep { width: 320px; }
+    .cmp-table-expr { width: auto; max-width: 420px; margin: 0 auto; }
+    .cmp-table-expr th, .cmp-table-expr td { padding: 6px 12px; font-size: 12px; }
+    .cmp-table-expr .th-chip { width: 130px; }
+    .cmp-table-expr .th-stat { width: 90px; }
     .cmp-table td {
       padding: 10px 12px; border-bottom: 1px solid var(--border);
       vertical-align: middle;
@@ -233,6 +242,18 @@
       &nbsp;&nbsp;Chip advice columns are merged by max-count (not summed) &mdash; JubJub's 9 cols absorb Native's 5.
       </span>
     </div>
+
+    <div class="cmp-wrap" style="margin-top:1rem;">
+      <table class="cmp-table cmp-table-cmp cmp-table-deps">
+        <thead>
+          <tr>
+            <th class="th-chip">Chip</th>
+            <th class="th-dep">Dependencies</th>
+          </tr>
+        </thead>
+        <tbody id="deps-tbody"></tbody>
+      </table>
+    </div>
   </div>
 
   <!-- Comparison tables -->
@@ -248,16 +269,19 @@
       <table class="cmp-table cmp-table-cmp">
         <thead>
           <tr>
-            <th class="th-chip">Chip</th>
-            <th class="th-dep">Dependencies</th>
-            <th class="th-stat">Adv cols</th>
-            <th class="th-stat">Fixed cols</th>
-            <th class="th-stat">Lookups</th>
-            <th class="th-stat">Trash</th>
-            <th class="th-stat">Evals</th>
-            <th class="th-size">Proof</th>
-            <th class="th-size">VK</th>
-            <th class="th-size">Total</th>
+            <th rowspan="2" class="th-chip">Chip</th>
+            <th rowspan="2" class="th-stat">Adv cols</th>
+            <th rowspan="2" class="th-stat">Fixed cols</th>
+            <th rowspan="2" class="th-stat">Lookups</th>
+            <th rowspan="2" class="th-stat">Trash</th>
+            <th colspan="3" class="th-group">Proof size</th>
+            <th colspan="2" class="th-group">VK size</th>
+            <th class="th-group">Total</th>
+          </tr>
+          <tr>
+            <th class="td-group-start th-stat">Com</th><th class="th-stat">Evals</th><th class="th-size">Bytes</th>
+            <th class="td-group-start th-stat">Com</th><th class="th-size">Bytes</th>
+            <th class="td-group-start th-size">Bytes</th>
           </tr>
         </thead>
         <tbody id="cmp-tbody"></tbody>
@@ -274,6 +298,24 @@
 
     <div class="subsection-title" style="margin-top:2rem;">Verifier Operation Counts</div>
     <div class="section-desc">
+      Number of individual scalar expressions contributed by each chip, before
+      batching into gate, lookup, and trashcan arguments.
+    </div>
+    <div class="cmp-wrap">
+      <table class="cmp-table cmp-table-cmp cmp-table-expr">
+        <thead>
+          <tr>
+            <th class="th-chip">Chip</th>
+            <th class="th-stat">Gate expr.</th>
+            <th class="th-stat">Lookup expr.</th>
+            <th class="th-stat">Trash expr.</th>
+          </tr>
+        </thead>
+        <tbody id="expr-tbody"></tbody>
+      </table>
+    </div>
+
+    <div class="section-desc" style="margin-top:1.5rem;">
       Minimum number of scalar operations required per chip summed across gate, lookup, and trashcan arguments as well as number of operations for the Multi-Scalar Multiplications (MSMs).
     </div>
     <div class="cmp-wrap">
@@ -316,6 +358,8 @@ const TABLE_CHIPS = [
   { name: 'Curve25519',     flag: '--curve25519',      key: 'curve25519'  },
   { name: 'Secp256k1',     flag: '--secp256k1',      key: 'secp256k1' },
   { name: 'Secp256r1',     flag: '--secp256r1',      key: 'secp256r1' },
+  { name: 'Automaton',     flag: '--automaton',      key: 'automaton' },
+  { name: 'Base64',        flag: '--base64',         key: 'base64'    },
 ];
 
 const KEY_TO_NAME = Object.fromEntries(TABLE_CHIPS.map(({ key, name }) => [key, name]));
@@ -325,6 +369,21 @@ function fmtBytes(b) {
 }
 
 function populate(profiles) {
+  // Dependency table.
+  const depsTbody = document.getElementById('deps-tbody');
+  TABLE_CHIPS.forEach(({ name, key }) => {
+    const chip = profiles[key];
+    if (!chip) { console.warn('No profile for chip: ' + key); return; }
+    const depsLabel = chip.deps && chip.deps.length
+      ? chip.deps.map(d => KEY_TO_NAME[d] || d).join(', ')
+      : '—';
+    const tr = document.createElement('tr');
+    tr.innerHTML =
+      '<td class="chip-name-cell">' + name + '</td>' +
+      '<td class="td-deps">' + depsLabel + '</td>';
+    depsTbody.appendChild(tr);
+  });
+
   // Comparison table.
   const tbody = document.getElementById('cmp-tbody');
   TABLE_CHIPS.forEach(({ name, flag, key }) => {
@@ -333,21 +392,19 @@ function populate(profiles) {
     const proof = fmtBytes(chip.proof_size);
     const vk    = fmtBytes(chip.vk_size);
     const total = fmtBytes(chip.proof_size + chip.vk_size);
-    const depsLabel = chip.deps && chip.deps.length
-      ? chip.deps.map(d => KEY_TO_NAME[d] || d).join(', ')
-      : '—';
     const tr    = document.createElement('tr');
     tr.innerHTML =
       '<td class="chip-name-cell">' + name + '</td>' +
-      '<td class="td-deps">' + depsLabel + '</td>' +
       '<td>' + chip.advice_cols + '</td>' +
       '<td>' + chip.fixed_cols + '</td>' +
       '<td>' + chip.lookups + '</td>' +
       '<td class="' + (chip.trash > 0 ? 'val-pink' : '') + '">' + chip.trash + '</td>' +
+      '<td class="td-group-start">' + chip.proof_commitments + '</td>' +
       '<td>' + chip.evals + '</td>' +
       '<td class="val-hi">' + proof + '</td>' +
+      '<td class="td-group-start">' + chip.vk_commitments + '</td>' +
       '<td>' + vk + '</td>' +
-      '<td class="val-hi">' + total + '</td>';
+      '<td class="val-hi td-group-start">' + total + '</td>';
     tbody.appendChild(tr);
   });
 
@@ -383,6 +440,20 @@ function populate(profiles) {
       '<td>'                        + msm.addG1 + '</td>' +
       '<td class="val-hi">'         + msm.mulG1 + '</td>';
     opsTbody.appendChild(tr);
+  });
+
+  // Scalar-expression counts, before batching into gate/lookup/trashcan arguments.
+  const exprTbody = document.getElementById('expr-tbody');
+  TABLE_CHIPS.forEach(({ name, key }) => {
+    const p = profiles[key];
+    if (!p) { console.warn('No profile for chip: ' + key); return; }
+    const tr = document.createElement('tr');
+    tr.innerHTML =
+      '<td class="chip-name-cell">' + name + '</td>' +
+      '<td>' + p.gate_expressions + '</td>' +
+      '<td>' + p.lookups + '</td>' +
+      '<td class="' + (p.trash > 0 ? 'val-pink' : '') + '">' + p.trash + '</td>';
+    exprTbody.appendChild(tr);
   });
 }
 

--- a/docs/chips.html
+++ b/docs/chips.html
@@ -315,6 +315,7 @@ const TABLE_CHIPS = [
   { name: 'Bls12-381',     flag: '--bls12-381',      key: 'bls12381'  },
   { name: 'Curve25519',     flag: '--curve25519',      key: 'curve25519'  },
   { name: 'Secp256k1',     flag: '--secp256k1',      key: 'secp256k1' },
+  { name: 'Secp256r1',     flag: '--secp256r1',      key: 'secp256r1' },
 ];
 
 const KEY_TO_NAME = Object.fromEntries(TABLE_CHIPS.map(({ key, name }) => [key, name]));
@@ -328,6 +329,7 @@ function populate(profiles) {
   const tbody = document.getElementById('cmp-tbody');
   TABLE_CHIPS.forEach(({ name, flag, key }) => {
     const chip  = profiles[key];
+    if (!chip) { console.warn('No profile for chip: ' + key); return; }
     const proof = fmtBytes(chip.proof_size);
     const vk    = fmtBytes(chip.vk_size);
     const total = fmtBytes(chip.proof_size + chip.vk_size);
@@ -353,6 +355,7 @@ function populate(profiles) {
   const opsTbody = document.getElementById('ops-tbody');
   TABLE_CHIPS.forEach(({ name, key: chipKey }) => {
     const p   = profiles[chipKey];
+    if (!p) { console.warn('No profile for chip: ' + chipKey); return; }
     const ops = ['neg', 'add', 'sub', 'mul', 'from_int'].reduce((acc, k) => {
       acc[k] = p.gate_ops[k] + p.lookup_ops[k] + p.trash_ops[k];
       return acc;

--- a/docs/cost-estimator.html
+++ b/docs/cost-estimator.html
@@ -533,6 +533,8 @@ cargo run <span class="flag">--bin</span> estimate -- \
         <div class="flags-section-title">Chips (combine as needed)</div>
         <table class="flags-table">
           <tr><td>--native</td><td>Arith chip (arithmetic + parallel_add gates)</td></tr>
+          <tr><td>--automaton</td><td>Regular expression parsing (automaton) chip</td></tr>
+          <tr><td>--base64</td><td>Base64 decoding chip</td></tr>
           <tr><td>--sha256</td><td>SHA256 hash chip</td></tr>
           <tr><td>--sha512</td><td>SHA512 hash chip</td></tr>
           <tr><td>--poseidon</td><td>Poseidon hash chip</td></tr>
@@ -540,6 +542,7 @@ cargo run <span class="flag">--bin</span> estimate -- \
           <tr><td>--hash-to-curve</td><td>Poseidon hash-to-JubJub-curve chip</td></tr>
           <tr><td>--curve25519</td><td>Curve25519 field/curve chip</td></tr>
           <tr><td>--secp256k1</td><td>Secp256k1 curve chip</td></tr>
+          <tr><td>--secp256r1</td><td>Secp256r1 curve chip</td></tr>
           <tr><td>--bls12-381</td><td>BLS12-381 curve chip</td></tr>
         </table>
 
@@ -591,6 +594,14 @@ cargo run <span class="flag">--bin</span> estimate -- \
       <p>Standard PLONK arithmetic gate + parallel_add gate. The baseline for any custom computation.</p>
     </div>
     <div class="chip-card">
+      <h4><span class="chip-tag">--automaton</span> Automaton</h4>
+      <p>Regular expression parsing via a fixed lookup-table automaton. Used for structural validation of committed byte strings.</p>
+    </div>
+    <div class="chip-card">
+      <h4><span class="chip-tag">--base64</span> Base64</h4>
+      <p>Base64 decoding chip. Used to decode base64-encoded data inside the circuit.</p>
+    </div>
+    <div class="chip-card">
       <h4><span class="chip-tag">--sha256</span> SHA256</h4>
       <p>Bitwise SHA256 hash chip. Used for hashing where SHA256 is required by the target protocol.</p>
     </div>
@@ -617,6 +628,10 @@ cargo run <span class="flag">--bin</span> estimate -- \
     <div class="chip-card">
       <h4><span class="chip-tag">--secp256k1</span> Secp256k1</h4>
       <p>Bitcoin/Ethereum elliptic curve. Supports ECDSA verification and threshold multisignature (ATMS) circuits.</p>
+    </div>
+    <div class="chip-card">
+      <h4><span class="chip-tag">--secp256r1</span> Secp256r1</h4>
+      <p>NIST P-256 elliptic curve. Supports ECDSA verification circuits such as WebAuthn and TLS.</p>
     </div>
     <div class="chip-card">
       <h4><span class="chip-tag">--bls12-381</span> BLS12-381</h4>

--- a/docs/cost.html
+++ b/docs/cost.html
@@ -459,6 +459,11 @@
           <span class="chip-name">secp256k1</span>
           <span class="chip-dep">⊃ Native</span>
         </label>
+        <label class="chip-toggle" id="ct-secp256r1">
+          <input type="checkbox" id="cb-secp256r1" onchange="update()" />
+          <span class="chip-name">secp256r1</span>
+          <span class="chip-dep">⊃ Native</span>
+        </label>
       </details>
 
       <div class="chip-profile-label" id="chip-profile-label">Active profile: <strong>none</strong></div>
@@ -717,9 +722,10 @@ const CHIP_ID_TO_RUST = {
   'cb-bls12381':  'WeierstrassBls12381',
   'cb-curve25519':  'Curve25519',
   'cb-secp256k1': 'WeierstrassSecp256k1',
+  'cb-secp256r1': 'WeierstrassSecp256r1',
 };
 
-const ALL_CHIP_KEYS = ['native', 'sha256', 'sha512', 'poseidon', 'jubjub', 'htc', 'bls12381', 'curve25519', 'secp256k1'];
+const ALL_CHIP_KEYS = ['native', 'sha256', 'sha512', 'poseidon', 'jubjub', 'htc', 'bls12381', 'curve25519', 'secp256k1', 'secp256r1'];
 
 // Chip profiles loaded from chip_profiles.json for client-side dep highlighting.
 let chipProfiles = {};

--- a/docs/cost.html
+++ b/docs/cost.html
@@ -466,6 +466,20 @@
         </label>
       </details>
 
+      <details class="chip-subgroup" open>
+        <summary>Parsing</summary>
+        <label class="chip-toggle" id="ct-automaton">
+          <input type="checkbox" id="cb-automaton" onchange="update()" />
+          <span class="chip-name">Automaton</span>
+          <span class="chip-dep">⊃ Native</span>
+        </label>
+        <label class="chip-toggle" id="ct-base64">
+          <input type="checkbox" id="cb-base64" onchange="update()" />
+          <span class="chip-name">Base64</span>
+          <span class="chip-dep">⊃ Native</span>
+        </label>
+      </details>
+
       <div class="chip-profile-label" id="chip-profile-label">Active profile: <strong>none</strong></div>
     </details>
 
@@ -723,9 +737,11 @@ const CHIP_ID_TO_RUST = {
   'cb-curve25519':  'Curve25519',
   'cb-secp256k1': 'WeierstrassSecp256k1',
   'cb-secp256r1': 'WeierstrassSecp256r1',
+  'cb-automaton': 'Automaton',
+  'cb-base64': 'Base64',
 };
 
-const ALL_CHIP_KEYS = ['native', 'sha256', 'sha512', 'poseidon', 'jubjub', 'htc', 'bls12381', 'curve25519', 'secp256k1', 'secp256r1'];
+const ALL_CHIP_KEYS = ['native', 'sha256', 'sha512', 'poseidon', 'jubjub', 'htc', 'bls12381', 'curve25519', 'secp256k1', 'secp256r1', 'automaton', 'base64'];
 
 // Chip profiles loaded from chip_profiles.json for client-side dep highlighting.
 let chipProfiles = {};

--- a/examples/secp256r1.rs
+++ b/examples/secp256r1.rs
@@ -1,0 +1,336 @@
+use anyhow::{Context as _, Result, anyhow};
+use log::info;
+use rand::prelude::StdRng;
+use rand_core::SeedableRng;
+
+use ff::{Field, PrimeField};
+use group::Group;
+use midnight_circuits::{
+    ecc::curves::CircuitCurve,
+    field::foreign::{AssignedField, params::MultiEmulationParams as MEP},
+    instructions::{
+        AssignmentInstructions, DecompositionInstructions, EccInstructions,
+        PublicInputInstructions, ZeroInstructions,
+    },
+    types::{AssignedForeignPoint, Instantiable},
+};
+use midnight_curves::{
+    Bls12, BlsScalar as Scalar, G1Projective,
+    p256::{Fp as P256Base, Fq as P256Scalar, P256},
+};
+use midnight_proofs::{
+    circuit::{Layouter, Value},
+    plonk::{
+        Error, ProvingKey, VerifyingKey, create_proof, k_from_circuit, keygen_pk, keygen_vk,
+        prepare,
+    },
+    poly::commitment::Guard,
+    poly::kzg::{KZGCommitmentScheme, params::ParamsKZG},
+    transcript::{CircuitTranscript, Transcript},
+};
+use midnight_zk_stdlib::{MidnightCircuit, Relation, ZkStdLib, ZkStdLibArch};
+use plutus_halo2_verifier_gen::{
+    kzg_params::get_or_create_kzg_params,
+    plutus_gen::{
+        CardanoFriendlyBlake2b, CircuitConfig, SupportedChips, cost_evaluation,
+        generate_aiken_verifier, generate_plinth_verifier,
+    },
+};
+
+type F = midnight_curves::Fq;
+type KZG = KZGCommitmentScheme<Bls12>;
+type Params = ParamsKZG<Bls12>;
+type CTranscript = CircuitTranscript<CardanoFriendlyBlake2b>;
+
+#[path = "shared_utils/mod.rs"]
+mod shared_utils;
+
+type PK = P256;
+type MsgHash = P256Scalar;
+
+/// Big-endian canonical byte representation of a `p256` field/scalar element.
+fn to_be_bytes<T: PrimeField>(v: &T) -> [u8; 32] {
+    v.to_repr().as_ref().try_into().unwrap()
+}
+
+/// Inverse of [`to_be_bytes`]. Returns `None` if `be` is not a canonical
+/// representative of `T` (e.g. a base-field x-coordinate that happens to
+/// exceed the scalar-field modulus).
+fn from_be_bytes<T: PrimeField>(be: [u8; 32]) -> Option<T> {
+    let mut repr = T::Repr::default();
+    repr.as_mut().copy_from_slice(&be);
+    Option::from(T::from_repr(repr))
+}
+
+/// A minimal ECDSA-over-secp256r1 signature. `r` is stored LE-encoded, as the
+/// x-coordinate of the nonce point `R = k*G` (an `P256Base` element)
+/// reinterpreted as a `P256Scalar` — the usual ECDSA cross-field trick, valid
+/// since secp256r1's base and scalar field moduli are close enough in size.
+#[derive(Clone, Copy, Debug)]
+struct P256Sig {
+    r: [u8; 32],
+    s: P256Scalar,
+}
+
+/// CPU-side ECDSA over secp256r1, mirroring
+/// `midnight_circuits::testing_utils::ecdsa::Ecdsa`, which only supports
+/// secp256k1 (k256). There is no P-256 equivalent upstream, so it is
+/// reimplemented here for this example.
+struct P256Ecdsa;
+
+impl P256Ecdsa {
+    fn keygen(rng: &mut StdRng) -> (PK, MsgHash) {
+        let sk = P256Scalar::random(&mut *rng);
+        let pk = P256::generator() * sk;
+        (pk, sk)
+    }
+
+    fn sign(sk: &MsgHash, msg_hash: &MsgHash, rng: &mut StdRng) -> P256Sig {
+        loop {
+            let k = P256Scalar::random(&mut *rng);
+            let k_point: P256 = P256::generator() * k;
+            let (r_as_base, _) = k_point.coordinates().expect("k*G is never the identity");
+
+            let r_be = to_be_bytes(&r_as_base);
+            let r_as_scalar = match from_be_bytes::<P256Scalar>(r_be) {
+                Some(v) => v,
+                None => continue, // r_as_base happened to exceed the scalar modulus; retry.
+            };
+
+            let k_inv = k.invert().unwrap();
+            let s = k_inv * (*msg_hash + r_as_scalar * sk);
+            if bool::from(s.is_zero()) {
+                continue;
+            }
+
+            // Big-endian canonical repr -> little-endian storage, matching
+            // the convention used throughout this repo's foreign-field code.
+            let mut r = r_be;
+            r.reverse();
+            return P256Sig { r, s };
+        }
+    }
+
+    fn verify(pk: &PK, msg_hash: &MsgHash, sig: &P256Sig) -> bool {
+        let mut r_be = sig.r;
+        r_be.reverse();
+        let r_as_scalar = from_be_bytes::<P256Scalar>(r_be).expect("valid scalar");
+        let r_as_base = from_be_bytes::<P256Base>(r_be).expect("valid base elt");
+
+        let s_inv = sig.s.invert().unwrap();
+        let k_point = P256::generator() * (s_inv * msg_hash) + *pk * (s_inv * r_as_scalar);
+
+        match k_point.coordinates() {
+            Some((x, _)) => x == r_as_base,
+            None => false,
+        }
+    }
+}
+
+/// Toy circuit: prove knowledge of a valid ECDSA signature over secp256r1
+/// (NIST P-256) for a public message hash and public key.
+/// Instance: message hash and public key `PK` on secp256r1.
+/// Witness:  a signature `(r, s)` valid under `PK` for the message hash.
+#[derive(Clone, Default)]
+struct P256EcdsaVerify;
+
+impl Relation for P256EcdsaVerify {
+    type Instance = (MsgHash, PK);
+
+    type Witness = P256Sig;
+
+    type Error = Error;
+
+    fn format_instance((msg_hash, pk): &Self::Instance) -> Result<Vec<F>, Error> {
+        Ok([
+            AssignedField::<F, P256Scalar, MEP>::as_public_input(msg_hash),
+            AssignedForeignPoint::<F, P256, MEP>::as_public_input(pk),
+        ]
+        .into_iter()
+        .flatten()
+        .collect())
+    }
+
+    fn circuit(
+        &self,
+        std_lib: &ZkStdLib,
+        layouter: &mut impl Layouter<F>,
+        instance: Value<Self::Instance>,
+        witness: Value<Self::Witness>,
+    ) -> Result<(), Error> {
+        let p256_curve = std_lib.p256();
+        let p256_scalar = std_lib.p256().scalar_field_chip();
+        let p256_base = std_lib.p256().base_field_chip();
+
+        // Assign the message hash as a public input.
+        let msg_hash = p256_scalar.assign_as_public_input(layouter, instance.unzip().0)?;
+
+        // Assign the PK and constrain it as a public input.
+        let pk = p256_curve.assign(layouter, instance.unzip().1)?;
+        p256_curve.constrain_as_public_input(layouter, &pk)?;
+
+        // Assign the witnessed signature. `-s` is assigned directly (rather
+        // than assigning `s` and negating in-circuit) since only `-s` is
+        // needed by the verification equation below.
+        let r_le_bytes =
+            std_lib.assign_many(layouter, &witness.map(|sig| sig.r).transpose_array())?;
+        let r_as_scalar = p256_scalar.assigned_from_le_bytes(layouter, &r_le_bytes)?;
+        let r_as_base = p256_base.assigned_from_le_bytes(layouter, &r_le_bytes)?;
+        let neg_s = p256_scalar.assign(layouter, witness.map(|sig| -sig.s))?;
+
+        // Witness K = R, the nonce point, whose x-coordinate is `r`. Only its
+        // y-coordinate needs assigning; `r_as_base` already carries the x.
+        let k_point_y_val =
+            witness
+                .zip(instance.unzip().0)
+                .zip(instance.unzip().1)
+                .map(|((sig, msg_hash), pk)| {
+                    let s_inv = sig.s.invert().unwrap();
+                    let mut r_be = sig.r;
+                    r_be.reverse();
+                    let r_as_scalar = from_be_bytes::<P256Scalar>(r_be).expect("valid scalar");
+                    let k_point =
+                        P256::generator() * (s_inv * msg_hash) + pk * (s_inv * r_as_scalar);
+
+                    // cpu sanity check
+                    let (x, y) = k_point.coordinates().expect("K is never the identity");
+                    let mut r_check = to_be_bytes(&x);
+                    r_check.reverse();
+                    assert_eq!(r_check, sig.r);
+                    y
+                });
+        let y = p256_base.assign(layouter, k_point_y_val)?;
+        let k_point = p256_curve.point_from_coordinates(layouter, &r_as_base, &y)?;
+
+        let gene = p256_curve.assign_fixed(layouter, P256::generator())?;
+
+        // Verify: msg_hash*G + r*PK - s*K = id.
+        let res = p256_curve.msm(
+            layouter,
+            &[msg_hash, r_as_scalar, neg_s],
+            &[gene, pk, k_point],
+        )?;
+
+        p256_curve.assert_zero(layouter, &res)
+    }
+
+    fn used_chips(&self) -> ZkStdLibArch {
+        ZkStdLibArch {
+            p256: true,
+            ..ZkStdLibArch::default()
+        }
+    }
+
+    fn write_relation<W: std::io::Write>(&self, _writer: &mut W) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    fn read_relation<R: std::io::Read>(_reader: &mut R) -> std::io::Result<Self> {
+        Ok(P256EcdsaVerify)
+    }
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let seed = [0u8; 32];
+    let mut rng: StdRng = SeedableRng::from_seed(seed);
+
+    // Generate a random instance-witness pair.
+    let msg_hash = P256Scalar::random(&mut rng);
+    let (pk, sk) = P256Ecdsa::keygen(&mut rng);
+    let signature = P256Ecdsa::sign(&sk, &msg_hash, &mut rng);
+
+    // Sanity check on the generated signature.
+    assert!(P256Ecdsa::verify(&pk, &msg_hash, &signature));
+
+    let instance = (msg_hash, pk);
+    let witness = signature;
+
+    let relation = P256EcdsaVerify;
+    let circuit = MidnightCircuit::new(
+        &relation,
+        Value::known(instance),
+        Value::known(witness),
+        None,
+    );
+    let k = k_from_circuit(&circuit);
+    let params: Params = get_or_create_kzg_params(k, rng.clone())?;
+    let vk: VerifyingKey<Scalar, KZG> = keygen_vk(&params, &circuit).context("keygen_vk failed")?;
+    let pk_proving: ProvingKey<Scalar, KZG> =
+        keygen_pk(vk.clone(), &circuit).context("keygen_pk failed")?;
+
+    let mut transcript = CTranscript::init();
+    let formatted_instance = P256EcdsaVerify::format_instance(&instance).unwrap();
+    create_proof(
+        &params,
+        &pk_proving,
+        &[circuit],
+        1,
+        &[&[&[], &formatted_instance]],
+        &mut transcript,
+        &mut rng,
+    )
+    .context("proof generation failed")?;
+    let proof = transcript.finalize();
+    info!("proof size: {}", proof.len());
+
+    let mut transcript_verifier = CTranscript::init_from_bytes(&proof);
+    let verifier = prepare::<_, KZG, CTranscript>(
+        &vk,
+        &[&[G1Projective::identity()]],
+        &[&[&formatted_instance]],
+        &mut transcript_verifier,
+    )
+    .context("prepare failed")?;
+    verifier
+        .verify(&params.verifier_params())
+        .map_err(|e| anyhow!("{e:?}"))
+        .context("verify failed")?;
+
+    let chips = &[SupportedChips::WeierstrassSecp256r1];
+    cost_evaluation(
+        &params,
+        &vk,
+        None,
+        &formatted_instance,
+        Some(G1Projective::identity()),
+        chips,
+        CircuitConfig {
+            ..Default::default()
+        },
+    )?;
+
+    let mut invalid_proof = proof.clone();
+    // index points to bytes of first scalar that is part of the proof
+    // this should be safe and not result in malformed encoding exception
+    // which is likely for flipping Byte for compressed G1 element
+    // simple mul has 24 G1 elements at the beginning of the proof each 48 bytes long
+    let index = 48 * 24 + 2;
+    let firs_byte = invalid_proof[index];
+    let negated_firs_byte = !firs_byte;
+    invalid_proof[index] = negated_firs_byte;
+
+    shared_utils::export_plinth(&formatted_instance, Some(G1Projective::identity()), &proof)?;
+    generate_plinth_verifier(
+        &params,
+        &vk,
+        None,
+        &formatted_instance,
+        Some(G1Projective::identity()),
+    )
+    .context("Plinth verifier generation failed")?;
+
+    shared_utils::export_aiken(&formatted_instance, Some(G1Projective::identity()), &proof)?;
+    generate_aiken_verifier(
+        &params,
+        &vk,
+        None,
+        &formatted_instance,
+        Some(G1Projective::identity()),
+        Some((proof.clone(), invalid_proof)),
+    )
+    .context("Aiken verifier generation failed")?;
+
+    Ok(())
+}

--- a/src/plutus_gen/stats/README.md
+++ b/src/plutus_gen/stats/README.md
@@ -116,6 +116,7 @@ CI will fail if `docs/wasm/` is stale relative to the Rust source.
 | `--htc` | `HashToCurve` | Hash-to-curve (JubJub) |
 | `--bls12-381` | `WeierstrassBls12381` | BLS12-381 ECC (foreign field, 7 limbs) |
 | `--secp256k1` | `WeierstrassSecp256k1` | secp256k1 ECC (foreign field, 4 limbs) |
+| `--secp256r1` | `WeierstrassSecp256r1` | secp256r1 ECC (foreign field, 4 limbs) |
 
 ---
 

--- a/src/plutus_gen/stats/README.md
+++ b/src/plutus_gen/stats/README.md
@@ -111,6 +111,8 @@ CI will fail if `docs/wasm/` is stale relative to the Rust source.
 | CLI flag | `SupportedChips` variant | Description |
 |----------|--------------------------|-------------|
 | `--native` | `Native` | Native field arithmetic |
+| `--automaton` | `Automaton` | Regular expression parsing (fixed lookup table) |
+| `--base64` | `Base64` | Base64 decoding |
 | `--poseidon` | `Poseidon` | Poseidon hash |
 | `--jubjub` | `EdwardsJubjub` | JubJub ECC (Edwards curve) |
 | `--htc` | `HashToCurve` | Hash-to-curve (JubJub) |

--- a/src/plutus_gen/stats/chips/mod.rs
+++ b/src/plutus_gen/stats/chips/mod.rs
@@ -40,8 +40,10 @@ pub enum SupportedChips {
     WeierstrassSecp256r1,
     #[strum(disabled)]
     P2RDecomposition(usize),
-    // Automaton,
-    // Base64,
+    #[strum(to_string = "automaton")]
+    Automaton,
+    #[strum(to_string = "base64")]
+    Base64,
     #[strum(disabled)]
     VerifierGadget,
     #[strum(disabled)]
@@ -264,8 +266,8 @@ impl_supported_chips! {
     WeierstrassBls12381  => WeierstrassBls12381,
     WeierstrassSecp256k1 => WeierstrassSecp256k1,
     WeierstrassSecp256r1 => WeierstrassSecp256r1,
-    // Automaton            => Automaton,
-    // Base64               => Base64,
+    Automaton            => Automaton,
+    Base64               => Base64,
 }
 
 /// Flattens `chips` and all their transitive `CHIP_DEPS` into a deduplicated set.

--- a/src/plutus_gen/stats/chips/mod.rs
+++ b/src/plutus_gen/stats/chips/mod.rs
@@ -36,7 +36,8 @@ pub enum SupportedChips {
     WeierstrassBls12381,
     #[strum(to_string = "secp256k1")]
     WeierstrassSecp256k1,
-    // WeierstrassSecp256r1,
+    #[strum(to_string = "secp256r1")]
+    WeierstrassSecp256r1,
     #[strum(disabled)]
     P2RDecomposition(usize),
     // Automaton,
@@ -262,7 +263,7 @@ impl_supported_chips! {
     EdwardsJubjub        => EdwardsJubjub,
     WeierstrassBls12381  => WeierstrassBls12381,
     WeierstrassSecp256k1 => WeierstrassSecp256k1,
-    // WeierstrassSecp256r1 => WeierstrassSecp256r1,
+    WeierstrassSecp256r1 => WeierstrassSecp256r1,
     // Automaton            => Automaton,
     // Base64               => Base64,
 }

--- a/src/plutus_gen/stats/chips/primitives/automaton.rs
+++ b/src/plutus_gen/stats/chips/primitives/automaton.rs
@@ -1,0 +1,58 @@
+use crate::plutus_gen::SupportedChips;
+
+use super::super::{Argument, Chip, Column, LookupTable, RotationSet, ScalarExpression};
+
+/// Static automaton parsing via a fixed lookup table.
+pub(crate) struct Automaton;
+
+impl Chip for Automaton {
+    fn advice_columns() -> Vec<Column> {
+        vec![
+            Column::advice(
+                RotationSet::new(false, false, true, true, false, false, false),
+                true,
+            ),
+            Column::advice(RotationSet::curr(), true),
+            Column::advice(RotationSet::curr(), true),
+            Column::advice(RotationSet::curr(), true),
+            Column::advice(RotationSet::curr(), true),
+            Column::advice(RotationSet::curr(), true),
+        ]
+    }
+
+    fn extra_columns() -> Vec<Column> {
+        vec![
+            Column::complex_selector(), // q_automaton
+        ]
+    }
+
+    fn lookup_args() -> Vec<Argument> {
+        vec![
+            vec![
+                ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+                ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+                ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+                ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+            ],
+            vec![
+                ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+                ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+                ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+                ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+            ],
+        ]
+    }
+
+    fn lookup_tables() -> Vec<LookupTable> {
+        vec![LookupTable::register("scanner".to_string(), 4)]
+    }
+
+    // NR_POW2RANGE_COLS set to 1 to follow zk_stdlib
+    fn nr_pow2range() -> usize {
+        1
+    }
+
+    fn chip_deps() -> Vec<crate::plutus_gen::SupportedChips> {
+        vec![SupportedChips::Native]
+    }
+}

--- a/src/plutus_gen/stats/chips/primitives/base64.rs
+++ b/src/plutus_gen/stats/chips/primitives/base64.rs
@@ -1,0 +1,44 @@
+use crate::plutus_gen::SupportedChips;
+
+use super::super::{Argument, Chip, Column, LookupTable, RotationSet, ScalarExpression};
+
+/// This module contains the `Base64Chip`, which implements Base64 decoding
+/// instructions.
+pub(crate) struct Base64;
+
+impl Chip for Base64 {
+    fn advice_columns() -> Vec<Column> {
+        vec![
+            Column::advice(RotationSet::curr(), false),
+            Column::advice(RotationSet::curr(), false),
+            Column::advice(RotationSet::curr(), false),
+            // Column::advice(RotationSet::default(), false),
+        ]
+    }
+
+    fn extra_columns() -> Vec<Column> {
+        vec![
+            Column::complex_selector(), // lookup_sel
+        ]
+    }
+
+    fn lookup_args() -> Vec<Argument> {
+        vec![vec![
+            ScalarExpression::lookup_expression(2, 1, 1, 3, 0, 3, 3),
+            ScalarExpression::lookup_expression(2, 1, 0, 0, 0, 1, 0),
+        ]]
+    }
+
+    fn lookup_tables() -> Vec<LookupTable> {
+        vec![LookupTable::register("base64".to_string(), 2)]
+    }
+
+    // NR_POW2RANGE_COLS set to 1 to follow zk_stdlib
+    fn nr_pow2range() -> usize {
+        1
+    }
+
+    fn chip_deps() -> Vec<crate::plutus_gen::SupportedChips> {
+        vec![SupportedChips::Native]
+    }
+}

--- a/src/plutus_gen/stats/chips/primitives/curve/bls12_381.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/bls12_381.rs
@@ -1,4 +1,4 @@
-use crate::plutus_gen::stats::chips::curve::{fe_to_bigint, to_bigint};
+use crate::plutus_gen::stats::chips::curve::{fe_to_bigint_le, to_bigint};
 
 use super::super::super::{Argument, Chip, Column, LookupTable, SupportedChips};
 use super::{
@@ -32,8 +32,12 @@ impl FieldEmulationParams for WeierstrassBls12381 {
 }
 
 impl WeierstrassEmulationParams for WeierstrassBls12381 {
+    fn a() -> BigInt {
+        fe_to_bigint_le(&<midnight_curves::G1Projective as WeierstrassCurve>::A)
+    }
+
     fn b() -> BigInt {
-        fe_to_bigint(&<midnight_curves::G1Projective as WeierstrassCurve>::B)
+        fe_to_bigint_le(&<midnight_curves::G1Projective as WeierstrassCurve>::B)
     }
 }
 

--- a/src/plutus_gen/stats/chips/primitives/curve/curve25519.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/curve25519.rs
@@ -1,5 +1,5 @@
 use super::field::{FieldChip, FieldChipTrait};
-use crate::plutus_gen::stats::chips::curve::{fe_to_bigint, to_bigint};
+use crate::plutus_gen::stats::chips::curve::{fe_to_bigint_le, to_bigint};
 
 use super::super::super::{Argument, Chip, Column, LookupTable, SupportedChips};
 use super::{EdwardsChip, EdwardsChipTrait, EdwardsEmulationParams, FieldEmulationParams};
@@ -42,11 +42,11 @@ impl FieldEmulationParams for Curve25519 {
 
 impl EdwardsEmulationParams for Curve25519 {
     fn a() -> BigInt {
-        fe_to_bigint(&curve25519::CURVE_A)
+        fe_to_bigint_le(&curve25519::CURVE_A)
     }
 
     fn d() -> BigInt {
-        fe_to_bigint(&curve25519::CURVE_D)
+        fe_to_bigint_le(&curve25519::CURVE_D)
     }
 }
 

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/edwards/addition.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/edwards/addition.rs
@@ -1,26 +1,26 @@
 use super::super::super::sum_bigints;
-use super::{EdwardsEmulationParams, EdwardsOpChipTrait, nb_advice_columns};
+use super::{
+    EdwardsColumnRanges, EdwardsEmulationParams, EdwardsOpChipTrait, column_ranges,
+    nb_advice_columns,
+};
 
-use crate::plutus_gen::stats::chips::curve::{non_trivial, non_zero, urem};
+use crate::plutus_gen::stats::chips::curve::{
+    count_non_trivial, count_non_zero, k_and_m_residues, non_trivial, non_zero,
+};
 use crate::plutus_gen::stats::chips::{Argument, Column, RotationSet, ScalarExpression};
 
 use num_bigint::BigInt;
-use num_traits::One;
 use std::ops::Rem;
 
 pub(crate) struct AdditionChip;
 
 impl AdditionChip {
     fn bounds<Params: EdwardsEmulationParams>() -> ((BigInt, BigInt), Vec<(BigInt, BigInt)>) {
-        let base = BigInt::from(2).pow(Params::LOG2_BASE);
-        let nb_limbs = Params::NB_LIMBS;
         let moduli = Params::moduli();
         let bs = Params::base_powers();
         let bs2 = Params::double_base_powers();
 
-        let limbs_max = vec![&base - BigInt::one(); nb_limbs as usize];
-        let limbs_max_sqrd_val = (&base - BigInt::one()).pow(2);
-        let limbs_max_sqrd = vec![limbs_max_sqrd_val.clone(); (nb_limbs * nb_limbs) as usize];
+        let (limbs_max, limbs_max_sqrd) = Params::limb_bounds();
 
         let max_sum = sum_bigints(&bs, &limbs_max);
         let max_sum_sqrd = sum_bigints(&bs2, &limbs_max_sqrd);
@@ -53,12 +53,12 @@ impl<P: EdwardsEmulationParams> EdwardsOpChipTrait<P> for AdditionChip {
         let nb_columns = nb_advice_columns::<P>();
         let mut columns: Vec<Column> = (0..nb_columns).map(|_| Column::empty_advice()).collect();
 
-        let x_cols = 0..P::NB_LIMBS;
-        // let y_cols = 0..P::NB_LIMBS;
-        let z_cols = P::NB_LIMBS..(2 * P::NB_LIMBS);
-        let u_col = P::NB_LIMBS;
-        let v_cols = (P::NB_LIMBS + 1)..(P::NB_LIMBS + 1 + P::moduli().len());
-        // let cond_col = x_cols.len() + v_cols.len() + 1;
+        let EdwardsColumnRanges {
+            x_cols,
+            z_cols,
+            u_col,
+            v_cols,
+        } = column_ranges::<P>();
 
         // Base Field_chip copy constraints x_cols and z_cols
         columns[x_cols.clone()]
@@ -135,23 +135,15 @@ impl<P: EdwardsEmulationParams> EdwardsOpChipTrait<P> for AdditionChip {
             .zip(vs_bounds)
             .for_each(|(mj, bounds_j)| {
                 let (lj_min, _vj_max) = bounds_j;
-                let k_min_m_urem_mj = urem(&(&k_min * &m), &mj);
-                let m_urem_mj = urem(&m, &mj);
-
-                let bij_powers_mj: Vec<BigInt> = dp.iter().map(|b| b.rem(mj)).collect();
-                let bi_powers_mj: Vec<BigInt> = bp.iter().map(|b| b.rem(mj)).collect();
+                let (k_min_m_urem_mj, m_urem_mj) = k_and_m_residues(&k_min, &m, mj);
 
                 // We compute the number of coefficients that:
                 // - are not 0s, so that we know we add the associated expression
                 // - are neither 0s or 1s, so that we multiply the associated expression (by non trivial nb)
-                let (bij_non_zero, bij_non_trivial) =
-                    bij_powers_mj.iter().fold((0, 0), |(acc0, acc1), bij| {
-                        (acc0 + non_zero(bij), acc1 + non_trivial(bij))
-                    });
-                let (bi_non_zero, bi_non_trivial) =
-                    bi_powers_mj.iter().fold((0, 0), |(acc0, acc1), bi| {
-                        (acc0 + non_zero(bi), acc1 + non_trivial(bi))
-                    });
+                let bij_non_zero = count_non_zero(&dp, mj);
+                let bij_non_trivial = count_non_trivial(&dp, mj);
+                let bi_non_zero = count_non_zero(&bp, mj);
+                let bi_non_trivial = count_non_trivial(&bp, mj);
 
                 let nb_neg = non_zero(&m_urem_mj) + non_zero(&k_min_m_urem_mj) + 4;
                 let nb_add = bij_non_zero

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/edwards/mod.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/edwards/mod.rs
@@ -25,6 +25,29 @@ pub(super) fn nb_advice_columns<P: EdwardsEmulationParams>() -> usize {
     P::NB_LIMBS + std::cmp::max(P::NB_LIMBS, 1 + P::moduli().len()) + 1
 }
 
+/// Column-index ranges shared by every `EdwardsOpChip` (currently just
+/// addition, but kept alongside `WeierstrassColumnRanges` for consistency
+/// should a second Edwards op-chip be added later).
+pub(super) struct EdwardsColumnRanges {
+    pub(super) x_cols: std::ops::Range<usize>,
+    pub(super) z_cols: std::ops::Range<usize>,
+    pub(super) u_col: usize,
+    pub(super) v_cols: std::ops::Range<usize>,
+}
+
+pub(super) fn column_ranges<P: EdwardsEmulationParams>() -> EdwardsColumnRanges {
+    let x_cols = 0..P::NB_LIMBS;
+    let z_cols = P::NB_LIMBS..(2 * P::NB_LIMBS);
+    let u_col = P::NB_LIMBS;
+    let v_cols = (P::NB_LIMBS + 1)..(P::NB_LIMBS + 1 + P::moduli().len());
+    EdwardsColumnRanges {
+        x_cols,
+        z_cols,
+        u_col,
+        v_cols,
+    }
+}
+
 pub struct EdwardsChip {}
 impl<P: FieldEmulationParams> FieldChipTrait<P> for EdwardsChip {}
 impl<P: EdwardsEmulationParams> EdwardsChipTrait<P> for EdwardsChip {}

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/lambda.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/lambda.rs
@@ -1,25 +1,26 @@
 use super::super::super::sum_bigints;
-use super::{WeierstrassEmulationParams, WierstrassOpChipTrait, nb_advice_columns};
+use super::{
+    WeierstrassColumnRanges, WeierstrassEmulationParams, WierstrassOpChipTrait, column_ranges,
+    nb_advice_columns,
+};
 
-use crate::plutus_gen::stats::chips::curve::{non_trivial, non_zero, urem};
+use crate::plutus_gen::stats::chips::curve::{
+    count_non_trivial, count_non_zero, k_and_m_residues, non_trivial, non_zero,
+};
 use crate::plutus_gen::stats::chips::{Argument, Column, ScalarExpression};
 
 use num_bigint::BigInt;
-use num_traits::One;
 use std::ops::Rem;
 
 pub(crate) struct Lambda2Chip;
 
 impl Lambda2Chip {
     fn bounds<Params: WeierstrassEmulationParams>() -> ((BigInt, BigInt), Vec<(BigInt, BigInt)>) {
-        let base = BigInt::from(2).pow(Params::LOG2_BASE);
-        let nb_limbs = Params::NB_LIMBS;
         let moduli = Params::moduli();
         let bs = Params::base_powers();
         let bs2 = Params::double_base_powers();
 
-        let limbs_max = vec![&base - BigInt::one(); nb_limbs];
-        let limbs_max2 = vec![(&base - BigInt::one()).pow(2); nb_limbs * nb_limbs];
+        let (limbs_max, limbs_max2) = Params::limb_bounds();
         let max_sum_px = sum_bigints(&bs, &limbs_max);
         let max_sum_qx = max_sum_px.clone();
         let max_sum_rx = max_sum_px.clone();
@@ -54,12 +55,13 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for Lambda2Chip {
         let nb_columns = nb_advice_columns::<P>();
         let mut columns: Vec<Column> = (0..nb_columns).map(|_| Column::empty_advice()).collect();
 
-        let x_cols = 0..P::NB_LIMBS;
-        // let y_cols = 0..P::NB_LIMBS;
-        let z_cols = P::NB_LIMBS..(2 * P::NB_LIMBS);
-        let u_col = P::NB_LIMBS;
-        let v_cols = (P::NB_LIMBS + 1)..(P::NB_LIMBS + 1 + P::moduli().len());
-        let cond_col = x_cols.len() + v_cols.len() + 1;
+        let WeierstrassColumnRanges {
+            x_cols,
+            z_cols,
+            u_col,
+            v_cols,
+            cond_col,
+        } = column_ranges::<P>();
 
         // Base Field_chip copy constraints x_cols and z_cols
         columns[x_cols.clone()]
@@ -133,23 +135,15 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for Lambda2Chip {
             .zip(vs_bounds)
             .for_each(|(mj, bounds_j)| {
                 let (lj_min, _vj_max) = bounds_j;
-                let k_min_m_urem_mj = urem(&(&k_min * &m), mj);
-                let m_urem_mj = urem(&m, mj);
-
-                let bij_powers_mj: Vec<BigInt> = dp.iter().map(|b| b.rem(mj)).collect();
-                let bi_powers_mj: Vec<BigInt> = bp.iter().map(|b| b.rem(mj)).collect();
+                let (k_min_m_urem_mj, m_urem_mj) = k_and_m_residues(&k_min, &m, mj);
 
                 // We compute the number of coefficients that:
                 // - are not 0s, so that we know we add the associated expression
                 // - are neither 0s or 1s, so that we multiply the associated expression (by non trivial nb)
-                let (bij_non_zero, bij_non_trivial) =
-                    bij_powers_mj.iter().fold((0, 0), |(acc0, acc1), bij| {
-                        (acc0 + non_zero(bij), acc1 + non_trivial(bij))
-                    });
-                let (bi_non_zero, bi_non_trivial) =
-                    bi_powers_mj.iter().fold((0, 0), |(acc0, acc1), bi| {
-                        (acc0 + non_zero(bi), acc1 + non_trivial(bi))
-                    });
+                let bij_non_zero = count_non_zero(&dp, mj);
+                let bij_non_trivial = count_non_trivial(&dp, mj);
+                let bi_non_zero = count_non_zero(&bp, mj);
+                let bi_non_trivial = count_non_trivial(&bp, mj);
 
                 let nb_neg = non_zero(&m_urem_mj) + non_zero(&k_min_m_urem_mj) + 3;
                 let nb_add = bij_non_zero

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/mod.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/mod.rs
@@ -31,6 +31,32 @@ pub(super) fn nb_advice_columns<P: WeierstrassEmulationParams>() -> usize {
     P::NB_LIMBS + std::cmp::max(P::NB_LIMBS, 2 + P::moduli().len()) + 1
 }
 
+/// Column-index ranges shared by every `WierstrassOpChip` (lambda, oncurve,
+/// slope, tangent): all four lay their columns out identically, differing
+/// only in which rotations of each range they query.
+pub(super) struct WeierstrassColumnRanges {
+    pub(super) x_cols: std::ops::Range<usize>,
+    pub(super) z_cols: std::ops::Range<usize>,
+    pub(super) u_col: usize,
+    pub(super) v_cols: std::ops::Range<usize>,
+    pub(super) cond_col: usize,
+}
+
+pub(super) fn column_ranges<P: WeierstrassEmulationParams>() -> WeierstrassColumnRanges {
+    let x_cols = 0..P::NB_LIMBS;
+    let z_cols = P::NB_LIMBS..(2 * P::NB_LIMBS);
+    let u_col = P::NB_LIMBS;
+    let v_cols = (P::NB_LIMBS + 1)..(P::NB_LIMBS + 1 + P::moduli().len());
+    let cond_col = x_cols.len() + v_cols.len() + 1;
+    WeierstrassColumnRanges {
+        x_cols,
+        z_cols,
+        u_col,
+        v_cols,
+        cond_col,
+    }
+}
+
 pub struct WeierstrassChip {}
 impl<P: FieldEmulationParams> FieldChipTrait<P> for WeierstrassChip {}
 impl<P: WeierstrassEmulationParams> WeierstrassChipTrait<P> for WeierstrassChip {}

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/oncurve.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/oncurve.rs
@@ -1,7 +1,12 @@
 use super::super::super::sum_bigints;
-use super::{WeierstrassEmulationParams, WierstrassOpChipTrait, nb_advice_columns};
+use super::{
+    WeierstrassColumnRanges, WeierstrassEmulationParams, WierstrassOpChipTrait, column_ranges,
+    nb_advice_columns,
+};
 
-use crate::plutus_gen::stats::chips::curve::{non_trivial, non_zero, urem};
+use crate::plutus_gen::stats::chips::curve::{
+    count_non_trivial, count_non_zero, k_and_m_residues, non_trivial, non_zero, signed_mod,
+};
 use crate::plutus_gen::stats::chips::{Argument, Column, ScalarExpression};
 
 use num_bigint::BigInt;
@@ -12,23 +17,32 @@ pub(crate) struct OnCurveChip;
 
 impl OnCurveChip {
     fn bounds<Params: WeierstrassEmulationParams>() -> ((BigInt, BigInt), Vec<(BigInt, BigInt)>) {
-        let base = BigInt::from(2).pow(Params::LOG2_BASE);
-        let nb_limbs = Params::NB_LIMBS;
         let moduli = Params::moduli();
         let bs = Params::base_powers();
         let bs2 = Params::double_base_powers();
 
-        let b = Params::b();
+        // (a+1)/(a+b) with a/b reduced to their signed representative closest
+        // to zero. Needed for curves like secp256r1 where a = -3: the unsigned
+        // residue p-3 would blow up the bounds.
+        let m = Params::modulus();
+        let a = signed_mod(&Params::a(), &m);
+        let b = signed_mod(&Params::b(), &m);
+        let a_plus_1 = &a + BigInt::one();
+        let a_plus_b = &a + &b;
 
-        let limbs_max = vec![&base - BigInt::one(); nb_limbs];
-        let limbs_max2 = vec![(&base - BigInt::one()).pow(2); nb_limbs * nb_limbs];
+        let (limbs_max, limbs_max2) = Params::limb_bounds();
         let max_sum_x = sum_bigints(&bs, &limbs_max);
         let max_sum_y = max_sum_x.clone();
         let max_sum_z = max_sum_x.clone();
         let max_sum_xz = sum_bigints(&bs2, &limbs_max2);
         let max_sum_y2 = max_sum_xz.clone();
-        let expr_min = -(&max_sum_xz + max_sum_z + max_sum_x + &b);
-        let expr_max = BigInt::from(2) * max_sum_y + max_sum_y2;
+
+        let expr_min =
+            -(&max_sum_xz + &max_sum_z + (&a_plus_1 * &max_sum_x).clone().max(BigInt::ZERO))
+                - &a_plus_b;
+        let expr_max = BigInt::from(2) * &max_sum_y + &max_sum_y2
+            - (&a_plus_1 * &max_sum_x).min(BigInt::ZERO)
+            - &a_plus_b;
 
         let expr_mj_bounds: Vec<_> = moduli
             .iter()
@@ -40,8 +54,15 @@ impl OnCurveChip {
                 let max_sum_z_mj = max_sum_x_mj.clone();
                 let max_sum_xz_mj = sum_bigints(&bs2_mj, &limbs_max2);
                 let max_sum_y2_mj = max_sum_xz_mj.clone();
-                let expr_mj_min = -(&max_sum_xz_mj + max_sum_z_mj + max_sum_x_mj + urem(&b, mj));
-                let expr_mj_max = BigInt::from(2) * max_sum_y_mj + max_sum_y2_mj;
+                let a_plus_1_mj = signed_mod(&a_plus_1, mj);
+                let a_plus_b_mj = signed_mod(&a_plus_b, mj);
+                let a1_sum_x_mj = &a_plus_1_mj * &max_sum_x_mj;
+                let expr_mj_min =
+                    -(&max_sum_xz_mj + max_sum_z_mj + a1_sum_x_mj.clone().max(BigInt::from(0)))
+                        - &a_plus_b_mj;
+                let expr_mj_max = BigInt::from(2) * max_sum_y_mj + max_sum_y2_mj
+                    - a1_sum_x_mj.min(BigInt::ZERO)
+                    - &a_plus_b_mj;
                 (expr_mj_min, expr_mj_max)
             })
             .collect();
@@ -54,12 +75,14 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for OnCurveChip {
         let nb_columns = nb_advice_columns::<P>();
         let mut columns: Vec<Column> = (0..nb_columns).map(|_| Column::empty_advice()).collect();
 
-        let x_cols = 0..P::NB_LIMBS;
-        let y_cols = 0..P::NB_LIMBS;
-        let z_cols = P::NB_LIMBS..(2 * P::NB_LIMBS);
-        let u_col = P::NB_LIMBS;
-        let v_cols = (P::NB_LIMBS + 1)..(P::NB_LIMBS + 1 + P::moduli().len());
-        let cond_col = x_cols.len() + v_cols.len() + 1;
+        let WeierstrassColumnRanges {
+            x_cols,
+            z_cols,
+            u_col,
+            v_cols,
+            cond_col,
+        } = column_ranges::<P>();
+        let y_cols = x_cols.clone();
 
         // Base Field_chip copy constraints x_cols and z_cols
         columns[x_cols.clone()]
@@ -115,19 +138,28 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for OnCurveChip {
         let dp = P::double_base_powers();
         let bp = P::base_powers();
         let m = P::modulus();
-        let b = P::b();
+        let a = signed_mod(&P::a(), &m);
+        let b = signed_mod(&P::b(), &m);
+        let a_plus_1 = &a + BigInt::one();
+        let a_plus_b = &a + &b;
 
         let dpl = dp.len();
         let bpl = bp.len();
 
-        // 2 * sum_y + sum_y2 - (sum_xz + sum_z + (a+1) * sum_x + b) = (u + k_min) * m
+        // 2 * sum_y + sum_y2 - (sum_xz + sum_z + (a + 1) * sum_x + (a + b))
+        // = (u + k_min) * m
         let native = ScalarExpression::gate_expression(
             4,
             2,
-            (bpl - 1) + 2 * dpl + 2 * bpl + 2 + non_zero(&k_min),
+            (bpl - 1) + 2 * dpl + 2 * bpl + 1 + non_zero(&k_min) + non_zero(&a_plus_b),
             0,
-            1 + 2 * dpl + 2 * (dpl - 1) + 3 * (bpl - 1) + 3,
-            2 * (dpl - 1) + 3 * (bpl - 1) + non_trivial(&k_min) + 3,
+            1 + 2 * dpl + 2 * (dpl - 1) + 3 * (bpl - 1) + 3 + non_trivial(&a_plus_1),
+            2 * (dpl - 1)
+                + 3 * (bpl - 1)
+                + non_trivial(&k_min)
+                + 2
+                + non_trivial(&a_plus_1)
+                + non_trivial(&a_plus_b),
         );
         gate.push(native);
 
@@ -136,52 +168,47 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for OnCurveChip {
             .zip(vs_bounds)
             .for_each(|(mj, bounds_j)| {
                 let (lj_min, _vj_max) = bounds_j;
-                let k_min_m_urem_mj = urem(&(&k_min * &m), mj);
-                let m_urem_mj = urem(&m, mj);
-                let b_urem_mj = urem(&b, mj);
-
-                let bij_powers_mj: Vec<BigInt> = dp.iter().map(|b| b.rem(mj)).collect();
-                let bi_powers_mj: Vec<BigInt> = bp.iter().map(|b| b.rem(mj)).collect();
+                let (k_min_m_urem_mj, m_urem_mj) = k_and_m_residues(&k_min, &m, mj);
+                let a_plus_1_mj = signed_mod(&a_plus_1, mj);
+                let a_plus_b_mj = signed_mod(&a_plus_b, mj);
 
                 // We compute the number of coefficients that:
                 // - are not 0s, so that we know we add the associated expression
                 // - are neither 0s or 1s, so that we multiply the associated expression (by non trivial nb)
-                let (bij_non_zero, bij_non_trivial) =
-                    bij_powers_mj.iter().fold((0, 0), |(acc0, acc1), bij| {
-                        (acc0 + non_zero(bij), acc1 + non_trivial(bij))
-                    });
-                let (bi_non_zero, bi_non_trivial) =
-                    bi_powers_mj.iter().fold((0, 0), |(acc0, acc1), bi| {
-                        (acc0 + non_zero(bi), acc1 + non_trivial(bi))
-                    });
+                let bij_non_zero = count_non_zero(&dp, mj);
+                let bij_non_trivial = count_non_trivial(&dp, mj);
+                let bi_non_zero = count_non_zero(&bp, mj);
+                let bi_non_trivial = count_non_trivial(&bp, mj);
 
                 let nb_neg = non_zero(&m_urem_mj) + non_zero(&k_min_m_urem_mj) + 2;
                 let nb_add = (bi_non_zero - 1)
                     + 2 * bij_non_zero
-                    + 2 * bi_non_zero
-                    + non_zero(&b_urem_mj)
+                    + (1 + non_zero(&a_plus_1_mj)) * bi_non_zero
+                    + non_zero(&a_plus_b_mj)
                     + non_zero(&m_urem_mj)
                     + non_zero(&k_min_m_urem_mj)
-                    + 1
+                    + non_zero(&a_plus_1_mj)
                     + non_zero(&lj_min);
                 let nb_mul = 1
                     + 2 * bij_non_trivial
                     + 2 * bij_non_zero
                     + 3 * bi_non_trivial
                     + non_trivial(&m_urem_mj)
+                    + non_trivial(&a_plus_1_mj)
                     + 2
                     + (bi_non_zero > 0) as usize;
                 let nb_from_int = 2 * bij_non_trivial
                     + 3 * bi_non_trivial
-                    + non_trivial(&b_urem_mj)
+                    + non_trivial(&a_plus_b_mj)
                     + non_trivial(&m_urem_mj)
                     + non_trivial(&k_min_m_urem_mj)
+                    + non_trivial(&a_plus_1_mj)
                     + non_trivial(&lj_min)
                     + 2;
 
-                //   3 * (2 * sum_px_mj + sum_px2_mj) + 1
-                // - 2 * (sum_py_mj + sum_lambda_mj + sum_lpy_mj)
-                // - u * (m % mj) - (k_min * m) % mj - (vj + lj_min) * mj = 0
+                // 2 * sum_y_mj + sum_y2_mj - (sum_xz_mj + sum_z_mj
+                //  + signed_mod(a + 1, mj) * sum_x_mj + signed_mod(a + b, mj))
+                //  - u * (m % mj) - (k_min * m) % mj - (vj + lj_min) * mj = 0
                 let modulo_id =
                     ScalarExpression::gate_expression(4, nb_neg, nb_add, 0, nb_mul, nb_from_int);
                 gate.push(modulo_id);

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/params.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/params.rs
@@ -4,6 +4,9 @@ use super::super::FieldEmulationParams;
 
 // Only takes as input the Base field emulation parameters
 pub(crate) trait WeierstrassEmulationParams: FieldEmulationParams {
+    // Curve parameter A
+    fn a() -> BigInt;
+
     // Curve parameter B
     fn b() -> BigInt;
 }

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/slope.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/slope.rs
@@ -1,25 +1,26 @@
 use super::super::super::sum_bigints;
-use super::{WeierstrassEmulationParams, WierstrassOpChipTrait, nb_advice_columns};
+use super::{
+    WeierstrassColumnRanges, WeierstrassEmulationParams, WierstrassOpChipTrait, column_ranges,
+    nb_advice_columns,
+};
 
-use crate::plutus_gen::stats::chips::curve::{non_trivial, non_zero, urem};
+use crate::plutus_gen::stats::chips::curve::{
+    count_non_trivial, count_non_zero, k_and_m_residues, non_trivial, non_zero,
+};
 use crate::plutus_gen::stats::chips::{Argument, Column, ScalarExpression};
 
 use num_bigint::BigInt;
-use num_traits::One;
 use std::ops::Rem;
 
 pub(crate) struct SlopeChip;
 
 impl SlopeChip {
     fn bounds<Params: WeierstrassEmulationParams>() -> ((BigInt, BigInt), Vec<(BigInt, BigInt)>) {
-        let base = BigInt::from(2).pow(Params::LOG2_BASE);
-        let nb_limbs = Params::NB_LIMBS;
         let moduli = Params::moduli();
         let bs = Params::base_powers();
         let bs2 = Params::double_base_powers();
 
-        let limbs_max = vec![&base - BigInt::one(); nb_limbs];
-        let limbs_max2 = vec![(&base - BigInt::one()).pow(2); nb_limbs * nb_limbs];
+        let (limbs_max, limbs_max2) = Params::limb_bounds();
         let max_sum_px = sum_bigints(&bs, &limbs_max);
         let max_sum_py = max_sum_px.clone();
         let max_sum_qx = max_sum_px.clone();
@@ -59,12 +60,13 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for SlopeChip {
         let nb_columns = nb_advice_columns::<P>();
         let mut columns: Vec<Column> = (0..nb_columns).map(|_| Column::empty_advice()).collect();
 
-        let x_cols = 0..P::NB_LIMBS;
-        // let y_cols = 0..P::NB_LIMBS;
-        let z_cols = P::NB_LIMBS..(2 * P::NB_LIMBS);
-        let u_col = P::NB_LIMBS;
-        let v_cols = (P::NB_LIMBS + 1)..(P::NB_LIMBS + 1 + P::moduli().len());
-        let cond_col = x_cols.len() + v_cols.len() + 1;
+        let WeierstrassColumnRanges {
+            x_cols,
+            z_cols,
+            u_col,
+            v_cols,
+            cond_col,
+        } = column_ranges::<P>();
 
         // Base Field_chip copy constraints x_cols and z_cols
         columns[x_cols.clone()]
@@ -139,23 +141,15 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for SlopeChip {
             .zip(vs_bounds)
             .for_each(|(mj, bounds_j)| {
                 let (lj_min, _vj_max) = bounds_j;
-                let k_min_m_urem_mj = urem(&(&k_min * &m), mj);
-                let m_urem_mj = urem(&m, mj);
-
-                let bij_powers_mj: Vec<BigInt> = dp.iter().map(|b| b.rem(mj)).collect();
-                let bi_powers_mj: Vec<BigInt> = bp.iter().map(|b| b.rem(mj)).collect();
+                let (k_min_m_urem_mj, m_urem_mj) = k_and_m_residues(&k_min, &m, mj);
 
                 // We compute the number of coefficients that:
                 // - are not 0s, so that we know we add the associated expression
                 // - are neither 0s or 1s, so that we multiply the associated expression (by non trivial nb)
-                let (bij_non_zero, bij_non_trivial) =
-                    bij_powers_mj.iter().fold((0, 0), |(acc0, acc1), bij| {
-                        (acc0 + non_zero(bij), acc1 + non_trivial(bij))
-                    });
-                let (bi_non_zero, bi_non_trivial) =
-                    bi_powers_mj.iter().fold((0, 0), |(acc0, acc1), bi| {
-                        (acc0 + non_zero(bi), acc1 + non_trivial(bi))
-                    });
+                let bij_non_zero = count_non_zero(&dp, mj);
+                let bij_non_trivial = count_non_trivial(&dp, mj);
+                let bi_non_zero = count_non_zero(&bp, mj);
+                let bi_non_trivial = count_non_trivial(&bp, mj);
 
                 let nb_neg = non_zero(&m_urem_mj) + non_zero(&k_min_m_urem_mj) + 5;
                 let nb_add = 2 * bij_non_zero

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/tangent.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/tangent.rs
@@ -1,7 +1,12 @@
 use super::super::super::sum_bigints;
-use super::{WeierstrassEmulationParams, WierstrassOpChipTrait, nb_advice_columns};
+use super::{
+    WeierstrassColumnRanges, WeierstrassEmulationParams, WierstrassOpChipTrait, column_ranges,
+    nb_advice_columns,
+};
 
-use crate::plutus_gen::stats::chips::curve::{non_trivial, non_zero, urem};
+use crate::plutus_gen::stats::chips::curve::{
+    count_non_trivial, count_non_zero, k_and_m_residues, non_trivial, non_zero, signed_mod,
+};
 use crate::plutus_gen::stats::chips::{Argument, Column, ScalarExpression};
 
 use num_bigint::BigInt;
@@ -12,22 +17,20 @@ pub(crate) struct TangentChip;
 
 impl TangentChip {
     fn bounds<Params: WeierstrassEmulationParams>() -> ((BigInt, BigInt), Vec<(BigInt, BigInt)>) {
-        let base = BigInt::from(2).pow(Params::LOG2_BASE);
-        let nb_limbs = Params::NB_LIMBS;
         let moduli = Params::moduli();
         let bs = Params::base_powers();
         let bs2 = Params::double_base_powers();
 
-        let limbs_max = vec![&base - BigInt::one(); nb_limbs];
-        let limbs_max2 = vec![(&base - BigInt::one()).pow(2); nb_limbs * nb_limbs];
+        let a_plus_1 = signed_mod(&Params::a(), &Params::modulus()) + BigInt::one();
+
+        let (limbs_max, limbs_max2) = Params::limb_bounds();
         let max_sum_px = sum_bigints(&bs, &limbs_max);
         let max_sum_py = max_sum_px.clone();
         let max_sum_lambda = max_sum_px.clone();
         let max_sum_px2 = sum_bigints(&bs2, &limbs_max2);
         let max_sum_lpy = max_sum_px2.clone();
-        let expr_min =
-            -BigInt::from(2) * (max_sum_py + max_sum_lambda + max_sum_lpy) + BigInt::one();
-        let expr_max = BigInt::from(3) * (&max_sum_px + &max_sum_px + max_sum_px2) + BigInt::one();
+        let expr_min = -BigInt::from(2) * (max_sum_py + max_sum_lambda + max_sum_lpy) + &a_plus_1;
+        let expr_max = BigInt::from(3) * (&max_sum_px + &max_sum_px + max_sum_px2) + &a_plus_1;
 
         let expr_mj_bounds: Vec<_> = moduli
             .iter()
@@ -39,12 +42,13 @@ impl TangentChip {
                 let max_sum_lambda_mj = max_sum_px_mj.clone();
                 let max_sum_px2_mj = sum_bigints(&bs2_mj, &limbs_max2);
                 let max_sum_lpy_mj = max_sum_px2_mj.clone();
+                let a_plus_1_mj = signed_mod(&a_plus_1, mj);
                 let expr_mj_min = -BigInt::from(2)
                     * (max_sum_py_mj + max_sum_lambda_mj + max_sum_lpy_mj)
-                    + BigInt::one();
+                    + &a_plus_1_mj;
                 let expr_mj_max = BigInt::from(3)
                     * (&max_sum_px_mj + &max_sum_px_mj + max_sum_px2_mj)
-                    + BigInt::one();
+                    + &a_plus_1_mj;
                 (expr_mj_min, expr_mj_max)
             })
             .collect();
@@ -58,12 +62,13 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for TangentChip {
         let nb_columns = nb_advice_columns::<P>();
         let mut columns: Vec<Column> = (0..nb_columns).map(|_| Column::empty_advice()).collect();
 
-        let x_cols = 0..P::NB_LIMBS;
-        // let y_cols = 0..P::NB_LIMBS;
-        let z_cols = P::NB_LIMBS..(2 * P::NB_LIMBS);
-        let u_col = P::NB_LIMBS;
-        let v_cols = (P::NB_LIMBS + 1)..(P::NB_LIMBS + 1 + P::moduli().len());
-        let cond_col = x_cols.len() + v_cols.len() + 1;
+        let WeierstrassColumnRanges {
+            x_cols,
+            z_cols,
+            u_col,
+            v_cols,
+            cond_col,
+        } = column_ranges::<P>();
 
         // Base Field_chip copy constraints x_cols and z_cols
         columns[x_cols.clone()]
@@ -136,23 +141,15 @@ impl<P: WeierstrassEmulationParams> WierstrassOpChipTrait<P> for TangentChip {
             .zip(vs_bounds)
             .for_each(|(mj, bounds_j)| {
                 let (lj_min, _vj_max) = bounds_j;
-                let k_min_m_urem_mj = urem(&(&k_min * &m), mj);
-                let m_urem_mj = urem(&m, mj);
-
-                let bij_powers_mj: Vec<BigInt> = dp.iter().map(|b| b.rem(mj)).collect();
-                let bi_powers_mj: Vec<BigInt> = bp.iter().map(|b| b.rem(mj)).collect();
+                let (k_min_m_urem_mj, m_urem_mj) = k_and_m_residues(&k_min, &m, mj);
 
                 // We compute the number of coefficients that:
                 // - are not 0s, so that we know we add the associated expression
                 // - are neither 0s or 1s, so that we multiply the associated expression (by non trivial nb)
-                let (bij_non_zero, bij_non_trivial) =
-                    bij_powers_mj.iter().fold((0, 0), |(acc0, acc1), bij| {
-                        (acc0 + non_zero(bij), acc1 + non_trivial(bij))
-                    });
-                let (bi_non_zero, bi_non_trivial) =
-                    bi_powers_mj.iter().fold((0, 0), |(acc0, acc1), bi| {
-                        (acc0 + non_zero(bi), acc1 + non_trivial(bi))
-                    });
+                let bij_non_zero = count_non_zero(&dp, mj);
+                let bij_non_trivial = count_non_trivial(&dp, mj);
+                let bi_non_zero = count_non_zero(&bp, mj);
+                let bi_non_trivial = count_non_trivial(&bp, mj);
 
                 let nb_neg = non_zero(&m_urem_mj) + non_zero(&k_min_m_urem_mj) + 2;
                 let nb_add = (bi_non_zero - 1)

--- a/src/plutus_gen/stats/chips/primitives/curve/field/mul.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/field/mul.rs
@@ -1,25 +1,23 @@
 use super::super::sum_bigints;
 use super::{FieldEmulationParams, FieldOpChip};
 
-use crate::plutus_gen::stats::chips::curve::{non_trivial, non_zero, urem};
+use crate::plutus_gen::stats::chips::curve::{
+    count_non_trivial, count_non_zero, k_and_m_residues, non_trivial, non_zero,
+};
 use crate::plutus_gen::stats::chips::{Argument, Column, ScalarExpression};
 
 use num_bigint::BigInt;
-use num_traits::One;
 use std::ops::Rem;
 
 pub(crate) struct MulChip;
 
 impl MulChip {
     fn bounds<Params: FieldEmulationParams>() -> ((BigInt, BigInt), Vec<(BigInt, BigInt)>) {
-        let base = BigInt::from(2).pow(Params::LOG2_BASE);
-        let nb_limbs = Params::NB_LIMBS;
         let moduli = Params::moduli();
         let base_powers = Params::base_powers();
         let double_base_powers = Params::double_base_powers();
 
-        let limbs_max = vec![&base - BigInt::one(); nb_limbs];
-        let limbs_max2 = vec![(&base - BigInt::one()).pow(2); nb_limbs * nb_limbs];
+        let (limbs_max, limbs_max2) = Params::limb_bounds();
         let max_sum_xy = sum_bigints(&double_base_powers, &limbs_max2);
         let max_sum_z = sum_bigints(&base_powers, &limbs_max);
         let max_sum_x = max_sum_z.clone();
@@ -128,23 +126,15 @@ impl<P: FieldEmulationParams> FieldOpChip<P> for MulChip {
             .zip(vs_bounds)
             .for_each(|(mj, bounds_j)| {
                 let (lj_min, _vj_max) = bounds_j;
-                let k_min_m_urem_mj = urem(&(&k_min * &m), mj);
-                let m_urem_mj = urem(&m, mj);
-
-                let bij_powers_mj: Vec<BigInt> = dp.iter().map(|b| b.rem(mj)).collect();
-                let bi_powers_mj: Vec<BigInt> = bp.iter().map(|b| b.rem(mj)).collect();
+                let (k_min_m_urem_mj, m_urem_mj) = k_and_m_residues(&k_min, &m, mj);
 
                 // We compute the number of coefficients that:
                 // - are not 0s, so that we know we add the associated expression
                 // - are neither 0s or 1s, so that we multiply the associated expression (by non trivial nb)
-                let (bij_non_zero, bij_non_trivial) =
-                    bij_powers_mj.iter().fold((0, 0), |(acc0, acc1), bij| {
-                        (acc0 + non_zero(bij), acc1 + non_trivial(bij))
-                    });
-                let (bi_non_zero, bi_non_trivial) =
-                    bi_powers_mj.iter().fold((0, 0), |(acc0, acc1), bi| {
-                        (acc0 + non_zero(bi), acc1 + non_trivial(bi))
-                    });
+                let bij_non_zero = count_non_zero(&dp, mj);
+                let bij_non_trivial = count_non_trivial(&dp, mj);
+                let bi_non_zero = count_non_zero(&bp, mj);
+                let bi_non_trivial = count_non_trivial(&bp, mj);
 
                 let nb_neg = (bi_non_zero > 0) as usize
                     + non_zero(&m_urem_mj)

--- a/src/plutus_gen/stats/chips/primitives/curve/field/norm.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/field/norm.rs
@@ -1,7 +1,9 @@
 use super::super::sum_bigints;
 use super::{FieldEmulationParams, FieldOpChip};
 
-use crate::plutus_gen::stats::chips::curve::{non_trivial, non_zero, urem};
+use crate::plutus_gen::stats::chips::curve::{
+    count_non_trivial, count_non_zero, k_and_m_residues, non_trivial, non_zero, urem,
+};
 use crate::plutus_gen::stats::chips::{Argument, Column, ScalarExpression};
 
 use num_bigint::BigInt;
@@ -123,19 +125,14 @@ impl<P: FieldEmulationParams> FieldOpChip<P> for NormChip {
             .zip(vs_bounds)
             .for_each(|(mj, bounds_j)| {
                 let (lj_min, _vj_max) = bounds_j;
-                let k_min_m_urem_mj = urem(&(&k_min * &m), mj);
-                let m_urem_mj = urem(&m, mj);
+                let (k_min_m_urem_mj, m_urem_mj) = k_and_m_residues(&k_min, &m, mj);
                 let sum_shifts_urem_mj = urem(&sum_shifts, mj);
-
-                let bi_powers_mj: Vec<BigInt> = bp.iter().map(|b| b.rem(mj)).collect();
 
                 // We compute the number of coefficients that:
                 // - are not 0s, so that we know we add the associated expression
                 // - are neither 0s or 1s, so that we multiply the associated expression (by non trivial nb)
-                let (bi_non_zero, bi_non_trivial) =
-                    bi_powers_mj.iter().fold((0, 0), |(acc0, acc1), bi| {
-                        (acc0 + non_zero(bi), acc1 + non_trivial(bi))
-                    });
+                let bi_non_zero = count_non_zero(&bp, mj);
+                let bi_non_trivial = count_non_trivial(&bp, mj);
 
                 let nb_neg = non_zero(&sum_shifts_urem_mj)
                     + non_zero(&m_urem_mj)

--- a/src/plutus_gen/stats/chips/primitives/curve/field/params.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/field/params.rs
@@ -95,4 +95,14 @@ pub(crate) trait FieldEmulationParams {
     fn max_limb_bound() -> BigInt {
         BigInt::from(2).pow(2 * Self::LOG2_BASE)
     }
+
+    /// The maximum value a single limb (`limbs_max`) or a pairwise product of
+    /// two limbs (`limbs_max2`) can take, replicated once per limb / limb-pair
+    /// position. Used by every gate's `bounds()` to size its worst-case sums.
+    fn limb_bounds() -> (Vec<BigInt>, Vec<BigInt>) {
+        let base = BigInt::from(2).pow(Self::LOG2_BASE);
+        let limbs_max = vec![&base - BigInt::one(); Self::NB_LIMBS];
+        let limbs_max2 = vec![(&base - BigInt::one()).pow(2); Self::NB_LIMBS * Self::NB_LIMBS];
+        (limbs_max, limbs_max2)
+    }
 }

--- a/src/plutus_gen/stats/chips/primitives/curve/mod.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/mod.rs
@@ -22,5 +22,8 @@ pub(crate) use jubjub::EdwardsJubjub;
 pub(crate) mod secp256k1;
 pub(crate) use secp256k1::WeierstrassSecp256k1;
 
+pub(crate) mod secp256r1;
+pub(crate) use secp256r1::WeierstrassSecp256r1;
+
 pub(crate) mod utils;
 pub(crate) use utils::*;

--- a/src/plutus_gen/stats/chips/primitives/curve/secp256r1.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/secp256r1.rs
@@ -1,5 +1,5 @@
 use super::field::{FieldChip, FieldChipTrait};
-use crate::plutus_gen::stats::chips::curve::to_bigint;
+use crate::plutus_gen::stats::chips::curve::{fe_to_bigint_be, to_bigint};
 
 use super::super::super::{Argument, Chip, Column, LookupTable, SupportedChips};
 use super::{
@@ -7,21 +7,21 @@ use super::{
 };
 
 use ff::PrimeField;
-use midnight_curves::k256;
+use midnight_curves::p256;
 use num_bigint::BigInt;
 use num_traits::One;
 
-/// Merged Weierstrass ECC, Base & Scalar Field chips for secp256k1 (foreign field, multi-limb via MEP).
-struct WeierstrassSecp256k1Scalar;
-pub(crate) struct WeierstrassSecp256k1;
+/// Merged Weierstrass ECC, Base & Scalar Field chips for Secp256r1 (foreign field, multi-limb via MEP).
+struct WeierstrassSecp256r1Scalar;
+pub(crate) struct WeierstrassSecp256r1;
 
-impl FieldEmulationParams for WeierstrassSecp256k1Scalar {
+impl FieldEmulationParams for WeierstrassSecp256r1Scalar {
     const LOG2_BASE: u32 = 64;
     const NB_LIMBS: usize = 4;
     const RC_LIMB_SIZE: usize = 17;
 
     fn modulus() -> BigInt {
-        to_bigint(k256::Fq::MODULUS)
+        to_bigint(p256::Fq::MODULUS)
     }
 
     fn moduli() -> Vec<BigInt> {
@@ -32,33 +32,36 @@ impl FieldEmulationParams for WeierstrassSecp256k1Scalar {
     }
 }
 
-impl FieldEmulationParams for WeierstrassSecp256k1 {
+impl FieldEmulationParams for WeierstrassSecp256r1 {
     const LOG2_BASE: u32 = 64;
     const NB_LIMBS: usize = 4;
-    const RC_LIMB_SIZE: usize = 16;
+    const RC_LIMB_SIZE: usize = 17;
 
     fn modulus() -> BigInt {
-        to_bigint(k256::Fp::MODULUS)
+        to_bigint(p256::Fp::MODULUS)
     }
 
     fn moduli() -> Vec<BigInt> {
-        vec![BigInt::from(2).pow(128)]
+        vec![
+            BigInt::from(2).pow(122),
+            BigInt::from(2).pow(122) - BigInt::from(507376),
+        ]
     }
 }
 
-impl WeierstrassEmulationParams for WeierstrassSecp256k1 {
+impl WeierstrassEmulationParams for WeierstrassSecp256r1 {
     fn a() -> BigInt {
-        BigInt::from(0)
+        fe_to_bigint_be(&p256::CURVE_A)
     }
     fn b() -> BigInt {
-        BigInt::from(7)
+        fe_to_bigint_be(&p256::CURVE_B)
     }
 }
 
-impl Chip for WeierstrassSecp256k1 {
+impl Chip for WeierstrassSecp256r1 {
     fn advice_columns() -> Vec<Column> {
-        let scalar_advices = <FieldChip as FieldChipTrait<WeierstrassSecp256k1Scalar>>::advice();
-        let ecc_advices = <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256k1>>::advice();
+        let scalar_advices = <FieldChip as FieldChipTrait<WeierstrassSecp256r1Scalar>>::advice();
+        let ecc_advices = <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256r1>>::advice();
 
         let max_len = std::cmp::max(scalar_advices.len(), ecc_advices.len());
         let mut columns: Vec<Column> = (0..max_len).map(|_| Column::empty_advice()).collect();
@@ -75,27 +78,27 @@ impl Chip for WeierstrassSecp256k1 {
     }
 
     fn extra_columns() -> Vec<Column> {
-        let scalar_fixed = <FieldChip as FieldChipTrait<WeierstrassSecp256k1Scalar>>::extra_fixed();
+        let scalar_fixed = <FieldChip as FieldChipTrait<WeierstrassSecp256r1Scalar>>::extra_fixed();
         let ecc_fixed =
-            <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256k1>>::extra_fixed();
+            <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256r1>>::extra_fixed();
 
         [scalar_fixed, ecc_fixed].concat()
     }
 
     fn gate_args() -> Vec<Argument> {
-        let scalar_args = <FieldChip as FieldChipTrait<WeierstrassSecp256k1Scalar>>::gates();
+        let scalar_args = <FieldChip as FieldChipTrait<WeierstrassSecp256r1Scalar>>::gates();
 
-        let ecc_args = <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256k1>>::gates();
+        let ecc_args = <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256r1>>::gates();
 
         [scalar_args, ecc_args].concat()
     }
 
     fn lookup_args() -> Vec<Argument> {
-        <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256k1>>::lookups()
+        <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256r1>>::lookups()
     }
 
     fn lookup_tables() -> Vec<LookupTable> {
-        <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256k1>>::lookup_tables()
+        <WeierstrassChip as WeierstrassChipTrait<WeierstrassSecp256r1>>::lookup_tables()
     }
 
     fn chip_deps() -> Vec<SupportedChips> {

--- a/src/plutus_gen/stats/chips/primitives/curve/utils.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/utils.rs
@@ -33,6 +33,15 @@ pub fn urem(value: &BigInt, modulus: &BigInt) -> BigInt {
     output
 }
 
+/// Reduces `value` modulo `modulus` using the representative closest to zero,
+/// i.e. in the range `(-modulus/2, modulus/2]`. This gives tighter bounds than
+/// `urem` when the unsigned representative is close to `modulus` (e.g. a
+/// curve's `a` coefficient, which is `-3` for secp256r1).
+pub fn signed_mod(value: &BigInt, modulus: &BigInt) -> BigInt {
+    let r = urem(value, modulus);
+    if &r * 2 > *modulus { r - modulus } else { r }
+}
+
 pub fn non_zero(value: &BigInt) -> usize {
     !value.is_zero() as usize
 }
@@ -41,14 +50,43 @@ pub fn non_trivial(value: &BigInt) -> usize {
     (!value.is_zero() && !value.is_one()) as usize
 }
 
+/// Counts how many of `values`, reduced mod `modulus`, are non-zero — i.e.
+/// need to be added into the gate expression.
+pub fn count_non_zero(values: &[BigInt], modulus: &BigInt) -> usize {
+    values.iter().map(|v| non_zero(&v.rem(modulus))).sum()
+}
+
+/// Counts how many of `values`, reduced mod `modulus`, are non-trivial (i.e.
+/// neither 0 nor 1) — i.e. need an extra multiplication by a constant, rather
+/// than a bare add.
+pub fn count_non_trivial(values: &[BigInt], modulus: &BigInt) -> usize {
+    values.iter().map(|v| non_trivial(&v.rem(modulus))).sum()
+}
+
+/// The two modulus-reduced quantities `((k_min * m) mod mj, m mod mj)` that
+/// every gate's per-modulus identity needs to account for the `u * m` and
+/// `k_min * m` terms of `expr = (u + k_min) * m` reduced mod `mj`.
+pub fn k_and_m_residues(k_min: &BigInt, m: &BigInt, mj: &BigInt) -> (BigInt, BigInt) {
+    (urem(&(k_min * m), mj), urem(m, mj))
+}
+
 pub fn to_bigint(modulo: &'static str) -> BigInt {
-    // Removing the "0x" before converting
-    BigUint::from_str_radix(&modulo[2..], 16)
+    let hex = modulo.strip_prefix("0x").unwrap_or(modulo);
+    BigUint::from_str_radix(hex, 16)
         .unwrap()
         .to_bigint()
         .unwrap()
 }
 
-pub fn fe_to_bigint<F: PrimeField>(value: &F) -> BigInt {
+/// Converts a field element to a `BigInt`, assuming `to_repr()` gives a
+/// little-endian canonical representation (true for bls12_381/curve25519).
+pub fn fe_to_bigint_le<F: PrimeField>(value: &F) -> BigInt {
     BigInt::from_bytes_le(Sign::Plus, F::to_repr(value).as_ref())
+}
+
+/// Like `fe_to_bigint_le`, but for fields whose `to_repr()` gives a big-endian
+/// canonical representation instead (true for k256/p256, which follow the
+/// SEC1 byte-order convention rather than the `ff`-crate LE convention).
+pub fn fe_to_bigint_be<F: PrimeField>(value: &F) -> BigInt {
+    BigInt::from_bytes_be(Sign::Plus, F::to_repr(value).as_ref())
 }

--- a/src/plutus_gen/stats/chips/primitives/mod.rs
+++ b/src/plutus_gen/stats/chips/primitives/mod.rs
@@ -1,3 +1,9 @@
+pub(crate) mod automaton;
+pub(crate) use automaton::Automaton;
+
+pub(crate) mod base64;
+pub(crate) use base64::Base64;
+
 pub(crate) mod curve;
 pub(crate) use curve::{
     Curve25519, EdwardsJubjub, HashToCurve, WeierstrassBls12381, WeierstrassSecp256k1,

--- a/src/plutus_gen/stats/chips/primitives/mod.rs
+++ b/src/plutus_gen/stats/chips/primitives/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod curve;
 pub(crate) use curve::{
     Curve25519, EdwardsJubjub, HashToCurve, WeierstrassBls12381, WeierstrassSecp256k1,
+    WeierstrassSecp256r1,
 };
 
 pub(crate) mod hash;

--- a/src/plutus_gen/stats/cli.rs
+++ b/src/plutus_gen/stats/cli.rs
@@ -74,6 +74,13 @@ pub struct EstimateCliArguments {
     #[arg(
         long,
         help_heading = "Chips",
+        help = "Include the secp256r1 curve chip."
+    )]
+    pub secp256r1: bool,
+
+    #[arg(
+        long,
+        help_heading = "Chips",
         help = "Include the Poseidon Hash to Jubjub Curve chip."
     )]
     pub hash_to_curve: bool,
@@ -164,6 +171,9 @@ impl EstimateCliArguments {
         }
         if self.secp256k1 {
             chips.push(SupportedChips::WeierstrassSecp256k1);
+        }
+        if self.secp256r1 {
+            chips.push(SupportedChips::WeierstrassSecp256r1);
         }
         chips
     }

--- a/src/plutus_gen/stats/cli.rs
+++ b/src/plutus_gen/stats/cli.rs
@@ -38,6 +38,16 @@ pub struct EstimateCliArguments {
     )]
     pub native: bool,
 
+    #[arg(
+        long,
+        help_heading = "Chips",
+        help = "Include regular expression parsing."
+    )]
+    pub automaton: bool,
+
+    #[arg(long, help_heading = "Chips", help = "Include Base64 operations.")]
+    pub base64: bool,
+
     #[arg(long, help_heading = "Chips", help = "Include the SHA256 hash chip.")]
     pub sha256: bool,
 
@@ -147,6 +157,12 @@ impl EstimateCliArguments {
         let mut chips = Vec::new();
         if self.native {
             chips.push(SupportedChips::Native);
+        }
+        if self.automaton {
+            chips.push(SupportedChips::Automaton);
+        }
+        if self.base64 {
+            chips.push(SupportedChips::Base64);
         }
         if self.jubjub {
             chips.push(SupportedChips::EdwardsJubjub);

--- a/src/plutus_gen/stats/estimate/mod.rs
+++ b/src/plutus_gen/stats/estimate/mod.rs
@@ -13,6 +13,16 @@ use proof::estimate_proof_size;
 use verifier::estimate_verifier_code;
 use vk::estimate_vk_size;
 
+/// Breakdown of a size estimate: number of commitments, number of scalar evaluations,
+/// and the resulting size in bytes (`commitments * 48 + evals * 32`, plus any constant
+/// overhead). VK estimates have no evaluations, so `evals` is always 0 for those.
+#[derive(Default, Clone, Copy)]
+pub(crate) struct SizeEstimate {
+    pub commitments: usize,
+    pub evals: usize,
+    pub bytes: usize,
+}
+
 /// All size and operation-count estimates for a circuit, computed in a single pass.
 ///
 /// Structural fields (nb_adv, nb_cc, …) reflect the merged result of all selected chips
@@ -141,7 +151,7 @@ pub fn all_estimates(
     let nb_comms = bc_advice + bc_perm + bc_trash + bc_vanish + bc_lookup + bc_pcs;
     let nb_scalars = bs_evals + bs_perm + bs_trash + bs_vanish + bs_lookup + bs_pcs;
     let proof_size = nb_comms * 48 + nb_scalars * 32;
-    let vk_size = estimate_vk_size::<H2MO>(nb_cc, nb_fixed);
+    let vk_size = estimate_vk_size::<H2MO>(nb_cc, nb_fixed).bytes;
     let input_size = nb_pi * 32 + nb_ci * 48;
 
     // ── Verifier stats (consumes `processed`) ─────────────────────────────────
@@ -222,6 +232,7 @@ pub fn proof_size(
         processed.nb_advice_fixed_evaluations,
         processed.nb_point_sets,
     )
+    .bytes
 }
 
 pub fn vk_size(
@@ -239,7 +250,7 @@ pub fn vk_size(
         used_chips,
     );
 
-    estimate_vk_size::<H2MO>(processed.nb_copy_constrained, processed.nb_fixed)
+    estimate_vk_size::<H2MO>(processed.nb_copy_constrained, processed.nb_fixed).bytes
 }
 
 pub fn verifier_stats(

--- a/src/plutus_gen/stats/estimate/proof.rs
+++ b/src/plutus_gen/stats/estimate/proof.rs
@@ -1,3 +1,4 @@
+use super::SizeEstimate;
 use crate::plutus_gen::stats::{
     arguments::permutation::{nb_perm_commitments, nb_perm_evaluations},
     arguments::{
@@ -30,7 +31,7 @@ pub(crate) fn estimate_proof_size<PCS: PcsEstimate>(
     nb_copy_constrained: usize,
     nb_evaluations: usize,
     nb_point_sets: usize,
-) -> usize {
+) -> SizeEstimate {
     // Commitments
     // - advice commitments: 1 per advice column
     // - permutation commitments: 1 per chunks of copy-constrained columns
@@ -59,7 +60,11 @@ pub(crate) fn estimate_proof_size<PCS: PcsEstimate>(
         + PCS::nb_evaluations(nb_point_sets);
 
     if nb_advice == 0 {
-        return 0;
+        return SizeEstimate::default();
     }
-    nb_commitments * 48 + nb_scalars * 32
+    SizeEstimate {
+        commitments: nb_commitments,
+        evals: nb_scalars,
+        bytes: nb_commitments * 48 + nb_scalars * 32,
+    }
 }

--- a/src/plutus_gen/stats/estimate/verifier.rs
+++ b/src/plutus_gen/stats/estimate/verifier.rs
@@ -55,9 +55,10 @@ where
         processed.nb_copy_constrained,
         processed.nb_advice_fixed_evaluations,
         processed.nb_point_sets,
-    );
+    )
+    .bytes;
 
-    let vk_size = estimate_vk_size::<PCS>(processed.nb_copy_constrained, processed.nb_fixed);
+    let vk_size = estimate_vk_size::<PCS>(processed.nb_copy_constrained, processed.nb_fixed).bytes;
 
     // Initializing CircuitStatistics with the estimated proof size, VK size, and number of public inputs.
     let mut stats = CircuitStatistics::new(

--- a/src/plutus_gen/stats/estimate/vk.rs
+++ b/src/plutus_gen/stats/estimate/vk.rs
@@ -1,3 +1,4 @@
+use super::SizeEstimate;
 use crate::plutus_gen::stats::{arguments::permutation::nb_perm_commitments_vk, pcs::PcsEstimate};
 
 /// Estimates the verification key size in bytes (compressed G1 elements only).
@@ -9,10 +10,16 @@ use crate::plutus_gen::stats::{arguments::permutation::nb_perm_commitments_vk, p
 pub(crate) fn estimate_vk_size<PCS: PcsEstimate>(
     nb_copy_constrained: usize,
     nb_fixed: usize,
-) -> usize {
+) -> SizeEstimate {
     if nb_copy_constrained == 0 || nb_fixed == 0 {
-        return 0;
+        return SizeEstimate::default();
     }
 
-    10 + 48 * (nb_fixed + nb_perm_commitments_vk(nb_copy_constrained) + PCS::nb_commitments_vk())
+    let commitments =
+        nb_fixed + nb_perm_commitments_vk(nb_copy_constrained) + PCS::nb_commitments_vk();
+    SizeEstimate {
+        commitments,
+        evals: 0,
+        bytes: 10 + 48 * commitments,
+    }
 }

--- a/src/plutus_gen/stats/profile.rs
+++ b/src/plutus_gen/stats/profile.rs
@@ -36,8 +36,11 @@ pub struct ChipProfile {
     pub copy_constraints: usize,
     pub nb_lookup_tables: usize,
     pub gates: usize,
+    pub gate_expressions: usize,
     pub lookups: usize,
     pub trash: usize,
+    pub proof_commitments: usize,
+    pub vk_commitments: usize,
     pub evals: usize,
     pub gate_ops: ScalarOps,
     pub lookup_ops: ScalarOps,
@@ -68,14 +71,17 @@ pub fn chip_profile<PCS: PcsEstimate>(chip: SupportedChips) -> ChipProfile {
 
     let lookup_args: Vec<Argument> = chips.iter().flat_map(|c| c.lookups()).collect();
     let nb_lookups = lookup_args.len();
+    let nb_lookup_scalars = lookup_args.iter().flatten().count();
 
     let trashcan_args: Vec<Argument> = chips.iter().flat_map(|c| c.trashcans()).collect();
     let nb_trashcans = trashcan_args.len();
+    let nb_trash_scalars = trashcan_args.iter().flatten().count();
 
     let circuit_degree = compute_degree(0, nb_copy_constrained, nb_lookups, nb_trashcans, &chips);
 
     let gate_args: Vec<Argument> = chips.iter().flat_map(|c| c.gates()).collect();
     let nb_gates = gate_args.len();
+    let nb_gate_scalars = gate_args.iter().flatten().count();
 
     // Creating permutation queries
     let permutation_queries = permutation_query_rotations(nb_copy_constrained, circuit_degree);
@@ -131,7 +137,7 @@ pub fn chip_profile<PCS: PcsEstimate>(chip: SupportedChips) -> ChipProfile {
     let trash_ops = fold_args(&trashcan_args);
 
     // Proof and VK sizes at pi=1, ci=0 (minimal baseline for this chip in isolation).
-    let proof_size = estimate_proof_size::<PCS>(
+    let proof_estimate = estimate_proof_size::<PCS>(
         0,
         nb_advice,
         nb_lookups,
@@ -141,7 +147,7 @@ pub fn chip_profile<PCS: PcsEstimate>(chip: SupportedChips) -> ChipProfile {
         nb_evaluations,
         nb_point_sets,
     );
-    let vk_size = estimate_vk_size::<PCS>(nb_copy_constrained, nb_fixed);
+    let vk_estimate = estimate_vk_size::<PCS>(nb_copy_constrained, nb_fixed);
     let nb_lookup_tables = tables.len();
 
     ChipProfile {
@@ -150,16 +156,19 @@ pub fn chip_profile<PCS: PcsEstimate>(chip: SupportedChips) -> ChipProfile {
         fixed_cols: nb_fixed,
         copy_constraints: nb_copy_constrained,
         nb_lookup_tables,
-        lookups: nb_lookups,
-        trash: nb_trashcans,
+        lookups: nb_lookup_scalars,
+        trash: nb_trash_scalars,
         degree: circuit_degree,
-        evals: nb_evaluations,
+        evals: proof_estimate.evals,
         gates: nb_gates,
+        gate_expressions: nb_gate_scalars,
         gate_ops,
         lookup_ops,
         trash_ops,
         commitment_map,
-        proof_size,
-        vk_size,
+        proof_commitments: proof_estimate.commitments,
+        vk_commitments: vk_estimate.commitments,
+        proof_size: proof_estimate.bytes,
+        vk_size: vk_estimate.bytes,
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -6,7 +6,7 @@ use crate::plutus_gen::{self, CircuitConfig, SupportedChips};
 ///
 /// `chips_json` is a JSON array where each element is either:
 /// - a string: `"Native"`,`"Sha256"`, `"Sha512"`, `"Poseidon"`, `"HashToCurve"`, `"Curve25519"`,
-///   `"EdwardsJubjub"`, `"WeierstrassBls12381"`, `"WeierstrassSecp256k1"`
+///   `"EdwardsJubjub"`, `"WeierstrassBls12381"`, `"WeierstrassSecp256k1"`, `"WeierstrassSecp256r1"`
 /// - an object: `{"type":"P2RDecomposition","n":5}` or
 ///   `{"type":"Lookup","name":"...","nb_arguments":1,"input_degree":1,"table_degree":1}`
 ///
@@ -92,6 +92,7 @@ fn chip_from_str(s: &str) -> Option<SupportedChips> {
         "Curve25519" => Some(SupportedChips::Curve25519),
         "WeierstrassBls12381" => Some(SupportedChips::WeierstrassBls12381),
         "WeierstrassSecp256k1" => Some(SupportedChips::WeierstrassSecp256k1),
+        "WeierstrassSecp256r1" => Some(SupportedChips::WeierstrassSecp256r1),
         _ => None,
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -5,8 +5,9 @@ use crate::plutus_gen::{self, CircuitConfig, SupportedChips};
 /// Compute all estimates for a circuit and return them as a JSON string.
 ///
 /// `chips_json` is a JSON array where each element is either:
-/// - a string: `"Native"`,`"Sha256"`, `"Sha512"`, `"Poseidon"`, `"HashToCurve"`, `"Curve25519"`,
-///   `"EdwardsJubjub"`, `"WeierstrassBls12381"`, `"WeierstrassSecp256k1"`, `"WeierstrassSecp256r1"`
+/// - a string: `"Native"`, `"Automaton"`, `"Base64"`, `"Sha256"`, `"Sha512"`, `"Poseidon"`,
+///   `"HashToCurve"`, `"Curve25519"`, `"EdwardsJubjub"`, `"WeierstrassBls12381"`,
+///   `"WeierstrassSecp256k1"`, `"WeierstrassSecp256r1"`
 /// - an object: `{"type":"P2RDecomposition","n":5}` or
 ///   `{"type":"Lookup","name":"...","nb_arguments":1,"input_degree":1,"table_degree":1}`
 ///
@@ -84,6 +85,8 @@ fn parse_chips(json: &str) -> Vec<SupportedChips> {
 fn chip_from_str(s: &str) -> Option<SupportedChips> {
     match s {
         "Native" => Some(SupportedChips::Native),
+        "Automaton" => Some(SupportedChips::Automaton),
+        "Base64" => Some(SupportedChips::Base64),
         "Sha256" => Some(SupportedChips::Sha256),
         "Sha512" => Some(SupportedChips::Sha512),
         "Poseidon" => Some(SupportedChips::Poseidon),


### PR DESCRIPTION
The curve Secp256r1 has a non trivial `b` coefficient which needed changes to the foreign ecc curves.

As such, not only does this PR add a chip but it also generalise some of the existing field and ecc chips.

This PR also adds Base64 and Automaton chips.

It also updates the website accordingly and adds extra tables to it.