### PR TITLE
Fixing IVC

### DIFF
--- a/examples/ivc.rs
+++ b/examples/ivc.rs
@@ -220,6 +220,9 @@ fn main() -> Result<()> {
     }
 
     let chips = &[];
+    // We set nr_pow2range_cols to 3 to mirror ivc_circuit configuration where
+    // Pow2RangeChip::configure(meta, &advice_columns[1..nb_parallel_range_checks]);
+    // with let nb_parallel_range_checks = NB_ARITH_COLS - 1; // = 4
     cost_evaluation(
         &kzg_params,
         &vk,
@@ -227,7 +230,10 @@ fn main() -> Result<()> {
         &instance,
         Some(C::identity()),
         chips,
-        CircuitConfig::default(),
+        CircuitConfig {
+            nr_pow2range_cols: Some(3),
+            ..CircuitConfig::default()
+        },
     )?;
 
     let mut invalid_proof = prev_proof.clone();

--- a/examples/ivc.rs
+++ b/examples/ivc.rs
@@ -2,7 +2,6 @@ use anyhow::{Context as _, Result};
 use log::info;
 use rand::prelude::StdRng;
 use rand_core::SeedableRng;
-use std::collections::BTreeMap;
 
 use ff::Field;
 use group::Group;
@@ -10,7 +9,7 @@ use group::Group;
 use midnight_circuits::{
     hash::poseidon::PoseidonState,
     types::{AssignedNative, Instantiable},
-    verifier::{Accumulator, AssignedAccumulator, AssignedVk, BlstrsEmulation, Msm, SelfEmulation},
+    verifier::{Accumulator, AssignedAccumulator, AssignedVk, BlstrsEmulation, SelfEmulation},
 };
 use midnight_curves::{Bls12, BlsScalar as Scalar};
 use midnight_proofs::{
@@ -89,7 +88,7 @@ macro_rules! verify_prepare {
             &[&[$public_inputs]],
             &mut transcript,
         )
-        .expect("Verification failed");
+        .expect(format!("{}th Verification preparation failed", $i).as_str());
         transcript
             .assert_empty()
             .expect("Transcript should be empty");
@@ -115,33 +114,9 @@ fn main() -> Result<()> {
     let vk = keygen_vk_with_k(&kzg_params, &default_ivc_circuit, k).unwrap();
     let pk = keygen_pk(vk.clone(), &default_ivc_circuit).unwrap();
 
-    let mut fixed_bases = BTreeMap::new();
-    fixed_bases.insert(String::from("com_instance"), C::identity());
-    fixed_bases.extend(midnight_circuits::verifier::fixed_bases::<S>(
-        "self_vk", &vk,
-    ));
+    let fixed_bases = midnight_circuits::verifier::fixed_bases::<S>("self_vk", &vk);
     let fixed_base_names = fixed_bases.keys().cloned().collect::<Vec<_>>();
-
-    // This trivial accumulator must have a single base and scalar of F::ONE, and
-    // the base has to be the default point of C. This is because when parsing
-    // an empty proof, our transcript gadget places a default point on every
-    // `read_point`. Note that the `base` is left untouched on during the
-    // handling of genesis, because `scale_by_bit` only modifies the scalars.
-    //
-    // On the other hand, the scalar has to be F::ONE because it is the value
-    // obtained after a `collapse` (the last step before constraining the acc as
-    // a public input).
-    let trivial_acc = Accumulator::<S>::new(
-        Msm::new(&[C::default()], &[F::ONE], &BTreeMap::new()),
-        Msm::new(
-            &[C::default()],
-            &[F::ONE],
-            &fixed_base_names
-                .iter()
-                .map(|name| (name.clone(), F::ZERO))
-                .collect(),
-        ),
-    );
+    let trivial_acc = Accumulator::<S>::trivial(&fixed_base_names);
 
     // Set the previous values for state (to genesis), proof and acc.
     let mut prev_state = F::ZERO;
@@ -217,13 +192,12 @@ fn main() -> Result<()> {
                 verify_prepare!(i, CTranscript, &proof, &vk, &instance)
             };
 
-            assert!(dual_msm.clone().check(&kzg_params.verifier_params()));
+            assert!(
+                dual_msm.clone().check(&kzg_params.verifier_params()),
+                "IVC proof verification failed"
+            );
 
-            let mut proof_acc: Accumulator<S> =
-                Accumulator::from_dual_msm(dual_msm, "inner_vk", &fixed_bases);
-            proof_acc.resolve_fixed_bases(&fixed_bases);
-            proof_acc.collapse();
-            proof_acc
+            Accumulator::from_dual_msm(dual_msm, "self_vk", &fixed_bases)
         };
 
         // Aggregating new accumulator with previous one, and checking both verify successfully.
@@ -260,8 +234,8 @@ fn main() -> Result<()> {
     // index points to bytes of first scalar that is part of the proof
     // this should be safe and not result in malformed encoding exception
     // which is likely for flipping Byte for compressed G1 element
-    // atms has 42 G1 elements at the beginning of the proof each 48 bytes long
-    let index = 48 * 42 + 2;
+    // atms has 41 G1 elements at the beginning of the proof each 48 bytes long
+    let index = 48 * 41 + 2;
     let firs_byte = invalid_proof[index];
     let negated_firs_byte = !firs_byte;
     invalid_proof[index] = negated_firs_byte;

--- a/plinth-verifier/plutus-halo2/plutus-halo2.cabal
+++ b/plinth-verifier/plutus-halo2/plutus-halo2.cabal
@@ -17,7 +17,6 @@ common common-lang
                -fno-strictness
                -fno-unbox-strict-fields
                -fno-unbox-small-strict-fields
-  PlutusTx.Plugin:defer-errors
 
 library
   import:           common-lang

--- a/src/circuits/ivc_circuit.rs
+++ b/src/circuits/ivc_circuit.rs
@@ -201,7 +201,7 @@ impl Circuit<F> for IvcCircuit {
 
         // Witness a proof and an accumulator that ensure the validity of `prev_state`.
         let prev_acc = {
-            let mut fixed_base_names = vec![String::from("com_instance")];
+            let mut fixed_base_names = vec![];
             fixed_base_names.extend(verifier::fixed_base_names::<S>(
                 self_vk_name,
                 self_cs.num_fixed_columns() + self_cs.num_selectors(),
@@ -221,7 +221,7 @@ impl Circuit<F> for IvcCircuit {
 
         let id_point = curve_chip.assign_fixed(&mut layouter, C::identity())?;
 
-        let assigned_pi = [
+        let prev_proof_pi = [
             verifier_chip.as_public_input(&mut layouter, &assigned_self_vk)?,
             vec![prev_state.clone()],
             verifier_chip.as_public_input(&mut layouter, &prev_acc)?,
@@ -232,11 +232,11 @@ impl Circuit<F> for IvcCircuit {
 
         // Verify a witnessed proof that ensures the validity of `prev_state`.
         // The proof is valid iff `proof_acc` satisfies the invariant.
-        let mut proof_acc = verifier_chip.prepare(
+        let mut prev_proof_acc = verifier_chip.prepare(
             &mut layouter,
             &assigned_self_vk,
             &[id_point],
-            &[&assigned_pi],
+            &[&prev_proof_pi],
             self.prev_proof.clone(),
         )?;
 
@@ -249,10 +249,8 @@ impl Circuit<F> for IvcCircuit {
             &mut layouter,
             &scalar_chip,
             &is_not_genesis,
-            &mut proof_acc,
+            &mut prev_proof_acc,
         )?;
-
-        proof_acc.collapse(&mut layouter, &curve_chip, &scalar_chip)?;
 
         // Accumulate the `proof_acc` with the previous witnessed accumulator.
         // `next_acc` will satisfy the invariant iff both `proof_acc` and `prev_acc` do.
@@ -261,7 +259,7 @@ impl Circuit<F> for IvcCircuit {
             &verifier_chip,
             &scalar_chip,
             &poseidon_chip,
-            &[proof_acc, prev_acc],
+            &[prev_proof_acc, prev_acc],
         )?;
 
         // Finally, collapse the resulting accumulator and constraint it as public.

--- a/src/circuits/ivc_circuit.rs
+++ b/src/circuits/ivc_circuit.rs
@@ -319,10 +319,6 @@ mod tests {
             "self_vk", &vk,
         ));
         let fixed_base_names = fixed_bases.keys().cloned().collect::<Vec<_>>();
-
-        // let fixed_bases = midnight_circuits::verifier::fixed_bases::<S>("self_vk", &vk);
-        // let fixed_base_names = fixed_bases.keys().cloned().collect::<Vec<_>>();
-
         let trivial_acc = Accumulator::<S>::trivial(&fixed_base_names);
 
         // Set the previous values for state (to genesis), proof and acc.

--- a/src/plutus_gen/emitters/aiken.rs
+++ b/src/plutus_gen/emitters/aiken.rs
@@ -13,6 +13,7 @@ use ff::Field;
 use group::{Curve, Group, GroupEncoding};
 use handlebars::{Handlebars, RenderError};
 use itertools::Itertools;
+use std::collections::BTreeMap;
 use std::{collections::HashMap, fs::File, iter::once, path::Path};
 
 /// A valid proof, an invalid proof, the public inputs, and the optional committed instance
@@ -648,31 +649,31 @@ where
 
             // We make the assumption that the accumulator has been collapsed.
             // As such, the lhs and rhs have both 1 base point and corresponding scalar, the rhs also has a fixed base.
-            // 2 points, each with x and y coordinate, each coordinate is 32 bytes when serialized, encodede deach in 7 limbs
+            // 2 points, each with x and y coordinate, each coordinate is 32 bytes when serialized, encoded each in 7 limbs, the limns are then packed together in 2 chunks (one of 4 limbs and one of 3)
             // 2 scalars
-            let serialized_acc = 2 * 2 * 7 + 2;
+            let serialized_acc = 2 * 2 * 2 + 2;
 
             let (fixed_bases, fixed_bases_len) = {
                 let mut ivc_fixed_bases = Vec::new();
                 let mut size = 0;
 
-                if nb_committed_instances > 0 {
-                    ivc_fixed_bases.push("ci_1".to_string());
-                    size += 1;
-                }
 
                 size += 1; // for G, which is always a fixed base
                 ivc_fixed_bases.push("neg_g1_generator".to_string());
 
-
+                let mut f_coms_order = BTreeMap::new();
                 circuit.proof_instantiation_data.fixed_commitments.iter().enumerate().for_each(|(i, _)| {
-                    ivc_fixed_bases.push(format!("f{}_commitment", i+1 ));
+                    f_coms_order.insert(format!("f_com_{}",i), format!("f{}_commitment", i+1));
                     size += 1;
                 });
+                ivc_fixed_bases.append(&mut f_coms_order.values().cloned().collect());
+
+                let mut p_coms_order = BTreeMap::new();
                 circuit.proof_instantiation_data.permutation_commitments.iter().enumerate().for_each(|(i, _)| {
-                    ivc_fixed_bases.push(format!("p{}_commitment", i+1 ));
+                    p_coms_order.insert(format!("p_com_{}",i), format!("p{}_commitment", i+1));
                     size += 1;
                 });
+                ivc_fixed_bases.append(&mut p_coms_order.values().cloned().collect());
 
                 recursion_vks.iter().for_each(|vki| {
                     vki.fixed_commitments.iter().enumerate().for_each(|(i, _)| {
@@ -700,31 +701,32 @@ where
             assert!(nb_public_inputs >= (nb_vks + fixed_bases_len + serialized_acc), "Not enough public inputs to support recursion. Required at least {}, but only {} provided.", fixed_bases_len + serialized_acc + nb_vks, nb_public_inputs);
 
 
-            let batching_coeff = "72057594037927936".to_string();
+            // (Bls12-381 P::LIMBS = 2^56)^4
+            let batching_coeff = "26959946667150639794667015087019630673637144422540572481103610249216".to_string();
             let base_field_modulo = "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab".to_string();
 
             let acc_left : String = {
-                let serialized_x = format!("    let acc_left_x_int = (1 + {}) % {base_field_modulo}\n", (0..7).fold("0".to_string(), |acc, i| {
-                        format!("(({} * {batching_coeff}) + to_int(i_{}))", acc, nb_public_inputs - fixed_bases_len - 3*7 - 2 - i)
+                let serialized_x = format!("    let acc_left_x_int = (1 + {}) % {base_field_modulo}\n", (0..2).fold("0".to_string(), |acc, i| {
+                        format!("(({} * {batching_coeff}) + to_int(i_{}))", acc, nb_public_inputs - fixed_bases_len - 3*2 - 2 - i)
                     }));
 
-                let serialized_y = format!("    let acc_left_y_int = (1 + {}) % {base_field_modulo}\n", (0..7).fold("0".to_string(), |acc, i| {
-                        format!("(({} * {batching_coeff}) + to_int(i_{}))", acc, nb_public_inputs - fixed_bases_len - 2*7 - 2 - i)
+                let serialized_y = format!("    let acc_left_y_int = (1 + {}) % {base_field_modulo}\n", (0..2).fold("0".to_string(), |acc, i| {
+                        format!("(({} * {batching_coeff}) + to_int(i_{}))", acc, nb_public_inputs - fixed_bases_len - 2*2 - 2 - i)
                     }));
 
                 let result = "    let acc_left_unscaled = g1_from_coords(acc_left_x_int, acc_left_y_int)\n".to_string();
-                let result2 = format!("    let acc_left = scaleG1(acc_left_unscaled, i_{})\n", nb_public_inputs - fixed_bases_len - 2*7 - 1).to_string();
+                let result2 = format!("    let acc_left = scaleG1(acc_left_unscaled, i_{})\n", nb_public_inputs - fixed_bases_len - 2*2 - 1).to_string();
 
                [serialized_x, serialized_y, result, result2].iter().join("")
             };
 
 
             let acc_right : String = {
-                let serialized_x = format!("\n    let acc_right_x_int = (1 + {}) % {base_field_modulo}\n", (0..7).fold("0".to_string(), |acc, i| {
-                        format!("(({} * {batching_coeff}) + to_int(i_{}))", acc, nb_public_inputs - fixed_bases_len - 7 - 1 - i)
+                let serialized_x = format!("\n    let acc_right_x_int = (1 + {}) % {base_field_modulo}\n", (0..2).fold("0".to_string(), |acc, i| {
+                        format!("(({} * {batching_coeff}) + to_int(i_{}))", acc, nb_public_inputs - fixed_bases_len - 2 - 1 - i)
                     }));
 
-                let serialized_y = format!("    let acc_right_y_int = (1 + {}) % {base_field_modulo}\n", (0..7).fold("0".to_string(), |acc, i| {
+                let serialized_y = format!("    let acc_right_y_int = (1 + {}) % {base_field_modulo}\n", (0..2).fold("0".to_string(), |acc, i| {
                         format!("(({} * {batching_coeff}) + to_int(i_{}))", acc, nb_public_inputs - fixed_bases_len - 1 - i)
                     }));
 
@@ -828,6 +830,12 @@ where
             );
         }
         Some((proof, invalid_proof, public_inputs, committed_instances_opt)) => {
+            let pis_condition = if circuit.proof_instantiation_data.recursion_vks.is_some() {
+                |x| x == 1
+            } else {
+                |x| x != 0
+            };
+
             let valid_pi = public_inputs
                 .iter()
                 .map(|e| format!("from_int(0x{})", hex::encode(e.to_bytes_be())))
@@ -837,7 +845,7 @@ where
                 .iter()
                 .enumerate()
                 .map(|(i, &e)| {
-                    let input = if i != 0 { e + Scalar::ONE } else { e };
+                    let input = if pis_condition(i) { e + Scalar::ONE } else { e };
                     format!("from_int(0x{})", hex::encode(input.to_bytes_be()))
                 })
                 .join(", ");
@@ -846,7 +854,7 @@ where
                 .iter()
                 .enumerate()
                 .map(|(i, &e)| {
-                    let input = if i != 0 { Scalar::ZERO } else { e };
+                    let input = if pis_condition(i) { Scalar::ZERO } else { e };
                     format!("from_int(0x{})", hex::encode(input.to_bytes_be()))
                 })
                 .join(", ");

--- a/src/plutus_gen/emitters/plinth.rs
+++ b/src/plutus_gen/emitters/plinth.rs
@@ -10,6 +10,7 @@ use crate::plutus_gen::extraction::pcs::{ExtractPCS, PCSType};
 use group::{GroupEncoding, prime::PrimeCurveAffine};
 use handlebars::{Handlebars, RenderError};
 use itertools::Itertools;
+use std::collections::BTreeMap;
 use std::{collections::HashMap, fs::File, path::Path};
 
 fn capitalize_first(s: &str) -> String {
@@ -684,29 +685,32 @@ where
 
             let final_check_vks = "&& b".to_string();
 
-            let serialized_acc = 2 * 2 * 7 + 2;
+             // We make the assumption that the accumulator has been collapsed.
+            // As such, the lhs and rhs have both 1 base point and corresponding scalar, the rhs also has a fixed base.
+            // 2 points, each with x and y coordinate, each coordinate is 32 bytes when serialized, encoded each in 7 limbs, the limns are then packed together in 2 chunks (one of 4 limbs and one of 3)
+            let serialized_acc = 2 * 2 * 2 + 2;
 
             let (fixed_bases, fixed_bases_len) = {
                 let mut ivc_fixed_bases = Vec::new();
                 let mut size = 0;
 
-                if nb_committed_instances > 0 {
-                    ivc_fixed_bases.push("ci1".to_string());
-                    size += 1;
-                }
 
                 size += 1;
                 ivc_fixed_bases.push("negGenG1".to_string());
 
-
+                let mut f_coms_order = BTreeMap::new();
                 circuit.proof_instantiation_data.fixed_commitments.iter().enumerate().for_each(|(i, _)| {
-                    ivc_fixed_bases.push(format!("f{}_commitment", i+1 ));
+                    f_coms_order.insert(format!("f_com_{}",i), format!("f{}_commitment", i+1));
                     size += 1;
                 });
+                ivc_fixed_bases.append(&mut f_coms_order.values().cloned().collect());
+
+                let mut p_coms_order = BTreeMap::new();
                 circuit.proof_instantiation_data.permutation_commitments.iter().enumerate().for_each(|(i, _)| {
-                    ivc_fixed_bases.push(format!("p{}_commitment", i+1 ));
+                    p_coms_order.insert(format!("p_com_{}",i), format!("p{}_commitment", i+1));
                     size += 1;
                 });
+                ivc_fixed_bases.append(&mut p_coms_order.values().cloned().collect());
 
                 recursion_vks.iter().for_each(|vki| {
                     vki.fixed_commitments.iter().enumerate().for_each(|(i, _)| {
@@ -723,34 +727,35 @@ where
                 (ivc_fixed_bases, size)
             };
 
-            assert!(nb_public_inputs >= (fixed_bases_len + serialized_acc), "Not enough public inputs to support recursion. Required at least {}, but only {} provided.", fixed_bases_len + serialized_acc, nb_public_inputs);
+            assert!(nb_public_inputs >= (fixed_bases_len + serialized_acc), "Not enough public inputs to support recursion. Required at least {} + {} = {}, but only {} provided.", fixed_bases_len ,serialized_acc, fixed_bases_len + serialized_acc, nb_public_inputs);
 
             let neg_g1 = "      !negGenG1 = bls12_381_G1_neg (bls12_381_G1_uncompress bls12_381_G1_compressed_generator)\n".to_string();
 
-            let batching_coeff = "72057594037927936".to_string();
+            // (Bls12-381 P::LIMBS = 2^56)^4
+            let batching_coeff = "26959946667150639794667015087019630673637144422540572481103610249216".to_string();
 
             let acc_left : String = {
-                let serialized_x = format!("      !acc_left_x = mkFp ((1 + {}) `modulo` bls12_381_base_prime)\n", (0..7).fold("0".to_string(), |acc, i| {
-                        format!("({} * {batching_coeff} + (unScalar i{}))", acc, nb_public_inputs - fixed_bases_len - 3*7 - 2 - i)
+                let serialized_x = format!("      !acc_left_x = mkFp ((1 + {}) `modulo` bls12_381_base_prime)\n", (0..2).fold("0".to_string(), |acc, i| {
+                        format!("({} * {batching_coeff} + (unScalar i{}))", acc, nb_public_inputs - fixed_bases_len - 3*2 - 2 - i)
                     }));
 
-                let serialized_y = format!("      !acc_left_y = mkFp ((1 + {}) `modulo` bls12_381_base_prime)\n", (0..7).fold("0".to_string(), |acc, i| {
-                        format!("({} * {batching_coeff} + (unScalar i{}))", acc, nb_public_inputs - fixed_bases_len - 2*7 - 2 - i)
+                let serialized_y = format!("      !acc_left_y = mkFp ((1 + {}) `modulo` bls12_381_base_prime)\n", (0..2).fold("0".to_string(), |acc, i| {
+                        format!("({} * {batching_coeff} + (unScalar i{}))", acc, nb_public_inputs - fixed_bases_len - 2*2 - 2 - i)
                     }));
 
                 let uncompressed  = "      !uncompressed_acc_left = BlsUtils.fromCoordsG1Point(acc_left_x, acc_left_y) \n".to_string();
 
-                let result = format!("      !acc_left = scale i{} uncompressed_acc_left\n", nb_public_inputs - fixed_bases_len - 2*7 - 1).to_string();
+                let result = format!("      !acc_left = scale i{} uncompressed_acc_left\n", nb_public_inputs - fixed_bases_len - 2*2 - 1).to_string();
 
                [serialized_x, serialized_y, uncompressed, result].iter().join("")
             };
 
             let acc_right : String = {
-                let serialized_x = format!("      !acc_right_x_int = mkFp ((1 + {}) `modulo` bls12_381_base_prime)\n", (0..7).fold("0".to_string(), |acc, i| {
-                        format!("({} * {batching_coeff} + (unScalar i{}))", acc, nb_public_inputs - fixed_bases_len - 7 - 1 - i)
+                let serialized_x = format!("      !acc_right_x_int = mkFp ((1 + {}) `modulo` bls12_381_base_prime)\n", (0..2).fold("0".to_string(), |acc, i| {
+                        format!("({} * {batching_coeff} + (unScalar i{}))", acc, nb_public_inputs - fixed_bases_len - 2 - 1 - i)
                     }));
 
-                let serialized_y = format!("      !acc_right_y_int = mkFp ((1 + {}) `modulo` bls12_381_base_prime)\n", (0..7).fold("0".to_string(), |acc, i| {
+                let serialized_y = format!("      !acc_right_y_int = mkFp ((1 + {}) `modulo` bls12_381_base_prime)\n", (0..2).fold("0".to_string(), |acc, i| {
                         format!("({} * {batching_coeff} + (unScalar i{}))", acc, nb_public_inputs - fixed_bases_len - 1 - i)
                     }));
 

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/edwards/mod.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/edwards/mod.rs
@@ -97,9 +97,7 @@ pub(crate) trait EdwardsChipTrait<P: EdwardsEmulationParams>: FieldChipTrait<P> 
     }
 
     fn fixed() -> Vec<Column> {
-        let columns = <AdditionChip as EdwardsOpChipTrait<P>>::fixed();
-
-        columns
+        <AdditionChip as EdwardsOpChipTrait<P>>::fixed()
     }
 
     fn extra_fixed() -> Vec<Column> {

--- a/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/mod.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/ecc/weierstrass/mod.rs
@@ -65,8 +65,7 @@ pub(crate) trait WeierstrassChipTrait<P: WeierstrassEmulationParams>:
     FieldChipTrait<P>
 {
     fn advice() -> Vec<Column> {
-        let ecc_len =
-            P::NB_LIMBS as usize + std::cmp::max(P::NB_LIMBS as usize, 2 + P::moduli().len()) + 1;
+        let ecc_len = P::NB_LIMBS + std::cmp::max(P::NB_LIMBS, 2 + P::moduli().len()) + 1;
         let lambda2_advices = <Lambda2Chip as WierstrassOpChipTrait<P>>::advice();
         let oncurve_advices = <OnCurveChip as WierstrassOpChipTrait<P>>::advice();
         let slope_advices = <SlopeChip as WierstrassOpChipTrait<P>>::advice();

--- a/src/plutus_gen/stats/chips/primitives/curve/jubjub.rs
+++ b/src/plutus_gen/stats/chips/primitives/curve/jubjub.rs
@@ -7,8 +7,8 @@ impl Chip for EdwardsJubjub {
     fn advice_columns() -> Vec<Column> {
         let current_next = RotationSet::new(false, false, true, true, false, false, false);
         vec![
-            Column::advice(current_next.clone(), true),
-            Column::advice(current_next.clone(), true),
+            Column::advice(current_next, true),
+            Column::advice(current_next, true),
             Column::advice(RotationSet::curr(), true),
             Column::advice(RotationSet::curr(), true),
             Column::advice(RotationSet::curr(), true),

--- a/src/plutus_gen/stats/chips/primitives/hash/poseidon.rs
+++ b/src/plutus_gen/stats/chips/primitives/hash/poseidon.rs
@@ -7,9 +7,9 @@ impl Chip for Poseidon {
     fn advice_columns() -> Vec<Column> {
         let current_next = RotationSet::new(false, false, true, true, false, false, false);
         vec![
-            Column::advice(current_next.clone(), true),
-            Column::advice(current_next.clone(), true),
-            Column::advice(current_next.clone(), true),
+            Column::advice(current_next, true),
+            Column::advice(current_next, true),
+            Column::advice(current_next, true),
             Column::advice(RotationSet::curr(), false),
             Column::advice(RotationSet::curr(), false),
             Column::advice(RotationSet::curr(), false),

--- a/src/plutus_gen/stats/chips/primitives/native.rs
+++ b/src/plutus_gen/stats/chips/primitives/native.rs
@@ -7,9 +7,9 @@ impl Chip for Native {
     fn advice_columns() -> Vec<Column> {
         let current_next = RotationSet::new(false, false, true, true, false, false, false);
         vec![
-            Column::advice(current_next.clone(), true),
-            Column::advice(current_next.clone(), true),
-            Column::advice(current_next.clone(), true),
+            Column::advice(current_next, true),
+            Column::advice(current_next, true),
+            Column::advice(current_next, true),
             Column::advice(RotationSet::curr(), true),
             Column::advice(RotationSet::curr(), true),
         ]

--- a/src/plutus_gen/stats/compute.rs
+++ b/src/plutus_gen/stats/compute.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 
 use crate::plutus_gen::extraction::data::{CircuitRepresentation, ProofExtractionSteps};
 use crate::plutus_gen::extraction::pcs::ExtractPCS;
-use crate::plutus_gen::stats::chips::{WeierstrassBls12381, curve::FieldEmulationParams};
 
 use super::data::CircuitStatistics;
 
@@ -56,6 +55,18 @@ where
                     let (c, s) = PCS::step_stat(step);
                     (acc.0 + c, acc.1 + s)
                 });
+        println!(
+            "proof comm: {} + {} = {}",
+            pes_commitments,
+            pcs_commitments,
+            pes_commitments + pcs_commitments
+        );
+        println!(
+            "proof scalars: {} + {} = {}",
+            pes_scalars,
+            pcs_scalars,
+            pes_scalars + pcs_scalars
+        );
         (pes_commitments + pcs_commitments) * 48 + (pes_scalars + pcs_scalars) * 32
     };
 
@@ -319,8 +330,8 @@ where
     if circuit.proof_instantiation_data.recursion_vks.is_some() {
         // Compute variable accumulator left point from public inputs
         (0..2).for_each(|_| {
-            // For both coordinates of the point, we reconstruct the coordinate
-            (0..WeierstrassBls12381::NB_LIMBS).for_each(|_| {
+            // For both coordinates of the point, we reconstruct the coordinate from the 2 chunks
+            (0..2).for_each(|_| {
                 stats.add_scalar();
                 stats.mul_scalar();
             });
@@ -331,8 +342,8 @@ where
         // Compute variable accumulator right point from public inputs
         // Compute variable accumulator left point from public inputs
         (0..2).for_each(|_| {
-            // For both coordinates of the point, we reconstruct the coordinate
-            (0..WeierstrassBls12381::NB_LIMBS).for_each(|_| {
+            // For both coordinates of the point, we reconstruct the coordinate from the 2 chunks
+            (0..2).for_each(|_| {
                 stats.add_scalar();
                 stats.mul_scalar();
             });

--- a/src/plutus_gen/stats/compute.rs
+++ b/src/plutus_gen/stats/compute.rs
@@ -341,10 +341,9 @@ where
 
         // Compute fixed accumulator
         let vk_len = vk.fixed_commitments().len() + vk.permutation().commitments().len();
-        // The MSM also comprises the negated generator, and 2 group elements
-        // for the public inputs and committed instances.
-        stats.msm(vk_len + 3);
-        (0..vk_len).for_each(|_| {
+        // The MSM also comprises the negated generator.
+        stats.msm(vk_len + 1);
+        (0..vk_len + 1).for_each(|_| {
             stats.decompress_point();
         });
 

--- a/src/plutus_gen/stats/compute.rs
+++ b/src/plutus_gen/stats/compute.rs
@@ -55,18 +55,6 @@ where
                     let (c, s) = PCS::step_stat(step);
                     (acc.0 + c, acc.1 + s)
                 });
-        println!(
-            "proof comm: {} + {} = {}",
-            pes_commitments,
-            pcs_commitments,
-            pes_commitments + pcs_commitments
-        );
-        println!(
-            "proof scalars: {} + {} = {}",
-            pes_scalars,
-            pcs_scalars,
-            pes_scalars + pcs_scalars
-        );
         (pes_commitments + pcs_commitments) * 48 + (pes_scalars + pcs_scalars) * 32
     };
 

--- a/src/plutus_gen/stats/data/circuit_statistics.rs
+++ b/src/plutus_gen/stats/data/circuit_statistics.rs
@@ -162,10 +162,14 @@ impl CircuitStatistics {
             mul_point: s1.mul_point.abs_diff(s2.mul_point),
             msm: {
                 let max_len = s1.msm.len().max(s2.msm.len());
+                let mut msm1 = s1.msm.clone();
+                let mut msm2 = s2.msm.clone();
+                msm1.sort_unstable();
+                msm2.sort_unstable();
                 (0..max_len)
                     .map(|i| {
-                        let a = s1.msm.get(i).cloned().unwrap_or(0);
-                        let b = s2.msm.get(i).cloned().unwrap_or(0);
+                        let a = msm1.get(i).cloned().unwrap_or(0);
+                        let b = msm2.get(i).cloned().unwrap_or(0);
                         a.abs_diff(b)
                     })
                     .collect()

--- a/src/plutus_gen/stats/estimate/verifier.rs
+++ b/src/plutus_gen/stats/estimate/verifier.rs
@@ -56,7 +56,9 @@ where
     )
     .bytes;
 
-    let vk_size = estimate_vk_size::<PCS>(processed.nb_copy_constrained, processed.nb_fixed).bytes;
+    let estimated_vk = estimate_vk_size::<PCS>(processed.nb_copy_constrained, processed.nb_fixed);
+    let vk_coms = estimated_vk.commitments;
+    let vk_size = estimated_vk.bytes;
 
     // Initializing CircuitStatistics with the estimated proof size, VK size, and number of public inputs.
     let mut stats = CircuitStatistics::new(
@@ -187,8 +189,8 @@ where
         stats.scale();
 
         // Compute fixed accumulator from vk and -g1
-        stats.msm(vk_size + 1);
-        (0..vk_size + 1).for_each(|_| {
+        stats.msm(vk_coms + 1);
+        (0..vk_coms + 1).for_each(|_| {
             stats.decompress_point();
         });
 

--- a/src/plutus_gen/stats/estimate/verifier.rs
+++ b/src/plutus_gen/stats/estimate/verifier.rs
@@ -5,9 +5,7 @@ use super::super::arguments::vanishing::compute_vanishing;
 use super::super::data::CircuitStatistics;
 use super::super::lookup::{LookupEstimate, PlookUp};
 use super::super::pcs::PcsEstimate;
-use crate::plutus_gen::stats::chips::{
-    ScalarExpression, WeierstrassBls12381, curve::FieldEmulationParams,
-};
+use crate::plutus_gen::stats::chips::ScalarExpression;
 use crate::plutus_gen::stats::estimate::build::Processed;
 use crate::plutus_gen::stats::estimate::{estimate_proof_size, estimate_vk_size};
 use log::info;
@@ -166,7 +164,8 @@ where
         // Compute variable accumulator left point from public inputs
         (0..2).for_each(|_| {
             // For both coordinates of the point, we reconstruct the coordinate
-            (0..WeierstrassBls12381::NB_LIMBS).for_each(|_| {
+            // The WeierstrassBls12381::NB_LIMBS limbs are packed into 2 chunks
+            (0..2).for_each(|_| {
                 stats.add_scalar();
                 stats.mul_scalar();
             });
@@ -178,7 +177,8 @@ where
         // Compute variable accumulator left point from public inputs
         (0..2).for_each(|_| {
             // For both coordinates of the point, we reconstruct the coordinate
-            (0..WeierstrassBls12381::NB_LIMBS).for_each(|_| {
+            // The WeierstrassBls12381::NB_LIMBS limbs are packed into 2 chunks
+            (0..2).for_each(|_| {
                 stats.add_scalar();
                 stats.mul_scalar();
             });

--- a/src/plutus_gen/stats/estimate/verifier.rs
+++ b/src/plutus_gen/stats/estimate/verifier.rs
@@ -186,9 +186,9 @@ where
         stats.g1_from_coords();
         stats.scale();
 
-        // Compute fixed accumulator from vk, -g1 and PIs
-        stats.msm(vk_size + 3);
-        (0..vk_size).for_each(|_| {
+        // Compute fixed accumulator from vk and -g1
+        stats.msm(vk_size + 1);
+        (0..vk_size + 1).for_each(|_| {
             stats.decompress_point();
         });
 


### PR DESCRIPTION
After bumping the midnight version, the IVC example was not working any longer.

This PR intends to fix it by:
- updating the IVC circuit and example not to add the committed instance to the accumulator's `fixed_bases`
- using midnight-zk API for the accumulator directly
- chunking the accumulator limbs and updating how the ex-limbs are recombined
- updating the accumulator fixed bases recomputation: the ordering between public inputs and vk commitment has changed
- Modifying invalid PIs computations for aiken tests so that only the state is updated and not all public inputs

The merit of these changes are:
- rely more on midnight-zk APIs, making the code simpler
- smaller verifier cost (thks to midnight-zk update)